### PR TITLE
Add support for querying tasks/workers in json

### DIFF
--- a/flower/models.py
+++ b/flower/models.py
@@ -27,7 +27,7 @@ class WorkersModel(BaseModel):
                     status=(workername in state.ping),
                     concurrency=pool.get('max-concurrency'),
                     completed_tasks=sum(stat['total'].itervalues()),
-                    running_tasks=len(state.active_tasks.get(workername, [])),
+                    running_tasks=state.active_tasks.get(workername, []),
                     queues=map(lambda x: x['name'],
                                state.active_queues.get(workername, [])),
                     )

--- a/flower/templates/workers.html
+++ b/flower/templates/workers.html
@@ -58,7 +58,7 @@
         </td>
         <td>{{ humanize(info['concurrency']) }}</td>
         <td>{{ info['completed_tasks'] }}</td>
-        <td>{{ info['running_tasks'] }}</td>
+        <td>{{ len(info['running_tasks']) }}</td>
         <td>{{ humanize(info['queues']) }}</td>
       </tr>
       {% end %}

--- a/flower/views/tasks.py
+++ b/flower/views/tasks.py
@@ -31,6 +31,10 @@ class TasksView(BaseHandler):
         workers = WorkersModel.get_workers(app)
         seen_task_types = TaskModel.seen_task_types(app)
 
+        if self.get_argument('mimetype', None) == 'application/json':
+            self.write({'tasks': [task for task in tasks]})
+            return
+
         self.render("tasks.html", tasks=tasks,
                                   task_types=seen_task_types,
                                   workers=workers,

--- a/flower/views/workers.py
+++ b/flower/views/workers.py
@@ -9,8 +9,13 @@ from ..models import WorkersModel, WorkerModel
 class WorkersView(BaseHandler):
     def get(self):
         app = self.application
-        self.render("workers.html",
-                workers=WorkersModel.get_latest(app).workers)
+        workers = WorkersModel.get_latest(app).workers
+
+        if self.get_argument('mimetype', None) == 'application/json':
+            self.write(workers)
+            return
+
+        self.render("workers.html", workers=workers)
 
 
 class WorkerView(BaseHandler):


### PR DESCRIPTION
Since Flower does such a nice job of caching celery state, and holding onto tasks, using it as a web-service is quite nice.
