### PR TITLE
Remove duplicate navbar

### DIFF
--- a/flower/templates/base.html
+++ b/flower/templates/base.html
@@ -19,7 +19,6 @@
     <link href="/static/css/flower.css" rel="stylesheet">
 
     {% block extra_styles %}
-        {% module Template("navbar.html", active_tab="") %}
     {% end %}
 
     <!--[if lt IE 9]>


### PR DESCRIPTION
On full width, duplicate navbars are on top of each other, so you don't really notice. Shrink the viewport down to trigger the media queries and you'll clearly see two navbars. Regardless, the `<head>` isn't the place for a navbar, I would argue.
