### PR TITLE
Rendering time = 0 as '-' instead of "1969-12-31 21:00:00".

### DIFF
--- a/flower/utils/template.py
+++ b/flower/utils/template.py
@@ -13,7 +13,7 @@ def humanize(obj, type=None, length=None):
     if obj is None:
         obj = ''
     elif type == 'time':
-        obj = datetime.fromtimestamp(float(obj)).strftime("%Y-%m-%d %H:%M:%S")
+        obj = datetime.fromtimestamp(float(obj)).strftime("%Y-%m-%d %H:%M:%S") if obj else '-'
     elif isinstance(obj, basestring) and not re.match(UUID_REGEX, obj):
         obj = obj.replace('-', ' ').replace('_', ' ')
         obj = re.sub('|'.join(KEYWORDS_UP),


### PR DESCRIPTION
On the Advanced task options table on the task detail view, succeeded (and other fields of type='time') time should be '-', not "1969-12-31 21:00:00" when task is not yet done.
