### PR TITLE
Use <pre> tag for traceback

### DIFF
--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -74,8 +74,10 @@
                     {% elif name == 'worker' %}
                     <a
                         href="{{ absolute_url('/worker/' + task.worker.hostname) }}">{{ task.worker.hostname }}</a>
+                    {% elif name == 'traceback' %}
+                    <pre>{{ getattr(task, name, None) }}</pre>
                     {% else %}
-                    {{ getattr(task, name, None) }}
+                      {{ getattr(task, name, None) }}
                     {% end %}
                   </td>
                 </tr>


### PR DESCRIPTION
Wrap the traceback in "pre" tag to improve readability
