### PR TITLE
Credentials not sent when sending HTTP request to API

### DIFF
--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -33,7 +33,6 @@ class RabbitMQ(BrokerBase):
         basic_auth = requests.auth.HTTPBasicAuth(self.username, self.password)
         r = requests.get(broker_url, auth=basic_auth)
 
-        print urljoin(self._broker_api_url, 'queues', self.vhost)
         if r.status_code == 200:
             info = r.json()
             return filter(lambda x: x['name'] in names, info)


### PR DESCRIPTION
There was an issue in broker.py and the way it used (it ignored them actually) the user credentials provided via the --broker-api command line parameter.

Something like this would never work:
--broker_api=http://someuser:somepassword@localhost:15672/api/

Since it always returned 401. The problem was that the credentials were never sent (confirmed using wireshark).

Added the requests related code to send the credentials using basic HTTP authentication. Now the error message "[E 130427 11:14:23 state:101] Failed to inspect the broker: 401 Client Error: None" dissapeared, credentials are sent in GET requests:

```
GET /api/queues HTTP/1.1
Host: localhost:15672
Authorization: Basic ...base64...
Content-Length: 0
Accept-Encoding: gzip, deflate, compress
Accept: */*
User-Agent: python-requests/1.0.4 CPython/2.7.3 Linux/3.2.0-40-generic
```

And the associated response contains a 200 code with some queue information on it.
