### PR TITLE
Fix --auth option using regexp

### DIFF
--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -3,6 +3,7 @@ import urllib
 
 from urlparse import urlparse, parse_qsl
 
+import re
 import tornado.web
 import tornado.auth
 
@@ -29,7 +30,7 @@ class LoginHandler(BaseHandler, tornado.auth.GoogleMixin):
     def _on_auth(self, user):
         if not user:
             raise tornado.web.HTTPError(500, 'Google auth failed')
-        if user['email'] not in self.application.auth:
+        if not re.match(self.application.auth, user['email']):
             raise tornado.web.HTTPError(404, "Access denied to '{email}'. "
                     "Please use another account or ask your admin to "
                     "add your email to flower --auth".format(**user))


### PR DESCRIPTION
New version uses regexp of emails instead of older version's comma-separated way, the relative part of flower/views/**init**.py has been modified, but i think u forget to modify it in flower/views/auth.py.
