### PR TITLE
Fix the show effect of task info page

### DIFF
--- a/flower/static/css/flower.css
+++ b/flower/static/css/flower.css
@@ -124,3 +124,10 @@
     margin-top: 20px;
     margin-bottom: 20px;
 }
+.span6 table {
+    table-layout:fixed;
+    word-wrap: break-word;
+}
+.span6 table caption + tbody tr td:first-child {
+    width: 25%;
+}


### PR DESCRIPTION
In this version, if line in the table is too long, it displays badly. Now, it displays better in ie8, firefox & chrome. I'm not a professional front-end web developer, so just fix it in 3 browsers mentioned before.
Before:
![_002](https://f.cloud.github.com/assets/1232624/528675/a2b88e8a-c127-11e2-8ad0-3e7d5e2c61d6.png)
After:
![_001](https://f.cloud.github.com/assets/1232624/528676/a8340218-c127-11e2-9792-978f98c1b9b8.png)
