### PR TITLE
Fix for double navbar on every page in web interface

### DIFF
--- a/flower/templates/base.html
+++ b/flower/templates/base.html
@@ -39,6 +39,7 @@
       </script>
 
     {% block navbar %}
+    {% module Template("navbar.html", active_tab="", absolute_url=absolute_url) %}
     {% end %}
 
     <div class="container-fluid">


### PR DESCRIPTION
The responsive navbar actually gets shown twice on every page – once from the base.html template and again on each individual page template.

You can't see it normally because they actually stack on top of each other, but when the window is small, it switches into "responsive mode" and you see two bars.

This fixes the problem by moving the default navbar include into the "navbar" block, so that it's overridden by each page that includes it's own navbar.
