### PR TITLE
Now works with Celery 3.1rc

### DIFF
--- a/flower/command.py
+++ b/flower/command.py
@@ -38,7 +38,7 @@ define("xheaders", type=bool, default=False,
 
 class FlowerCommand(Command):
 
-    def run_from_argv(self, prog_name, argv=None):
+    def run_from_argv(self, prog_name, argv=None, **_kwargs):
         app_settings = settings.APP_SETTINGS
         argv = filter(self.flower_option, argv)
         parse_command_line([prog_name] + argv)


### PR DESCRIPTION
run_from_argv now takes command= kwarg
