### PR TITLE
Let the logger merge in the formatting arguments, so that logs can be grouped.

### DIFF
--- a/flower/api/control.py
+++ b/flower/api/control.py
@@ -20,7 +20,7 @@ class WorkerShutDown(ControlHandler):
             raise web.HTTPError(404, "Unknown worker '%s'" % workername)
         celery = self.application.celery_app
 
-        logging.info("Shutting down '%s' worker" % workername)
+        logging.info("Shutting down '%s' worker", workername)
         celery.control.broadcast('shutdown', destination=[workername])
         self.write(dict(message="Shutting down!"))
 
@@ -32,7 +32,7 @@ class WorkerPoolRestart(ControlHandler):
             raise web.HTTPError(404, "Unknown worker '%s'" % workername)
         celery = self.application.celery_app
 
-        logging.info("Restarting '%s' worker's pool" % workername)
+        logging.info("Restarting '%s' worker's pool", workername)
         response = celery.control.broadcast('pool_restart',
                                             arguments={'reload': False},
                                             destination=[workername],
@@ -55,7 +55,7 @@ class WorkerPoolGrow(ControlHandler):
 
         n = int(self.get_argument('n', 1))
 
-        logging.info("Growing '%s' worker's pool by '%s'" % (workername, n))
+        logging.info("Growing '%s' worker's pool by '%s'", workername, n)
         response = celery.control.broadcast('pool_grow',
                                             arguments={'n': n},
                                             destination=[workername],
@@ -77,7 +77,7 @@ class WorkerPoolShrink(ControlHandler):
 
         n = int(self.get_argument('n', 1))
 
-        logging.info("Shrinking '%s' worker's pool by '%s'" % (workername, n))
+        logging.info("Shrinking '%s' worker's pool by '%s'", workername, n)
         response = celery.control.broadcast('pool_shrink',
                                             arguments={'n': n},
                                             destination=[workername],
@@ -101,8 +101,8 @@ class WorkerPoolAutoscale(ControlHandler):
         min = int(self.get_argument('min'))
         max = int(self.get_argument('max'))
 
-        logging.info("Autoscaling '%s' worker by '%s'" %
-                     (workername, (min, max)))
+        logging.info("Autoscaling '%s' worker by '%s'",
+                     workername, (min, max))
         response = celery.control.broadcast('autoscale',
                                             arguments={'min': min, 'max': max},
                                             destination=[workername],
@@ -129,8 +129,8 @@ class WorkerQueueAddConsumer(ControlHandler):
 
         queue = self.get_argument('queue')
 
-        logging.info("Adding consumer '%s' to worker '%s'" %
-                     (queue, workername))
+        logging.info("Adding consumer '%s' to worker '%s'",
+                     queue, workername)
         response = celery.control.broadcast('add_consumer',
                                             arguments={'queue': queue},
                                             destination=[workername],
@@ -157,8 +157,8 @@ class WorkerQueueCancelConsumer(ControlHandler):
 
         queue = self.get_argument('queue')
 
-        logging.info("Canceling consumer '%s' from worker '%s'" %
-                     (queue, workername))
+        logging.info("Canceling consumer '%s' from worker '%s'",
+                     queue, workername)
         response = celery.control.broadcast('cancel_consumer',
                                             arguments={'queue': queue},
                                             destination=[workername],
@@ -179,7 +179,7 @@ class WorkerQueueCancelConsumer(ControlHandler):
 class TaskRevoke(BaseHandler):
     @web.authenticated
     def post(self, taskid):
-        logging.info("Revoking task '%s'" % taskid)
+        logging.info("Revoking task '%s'", taskid)
         celery = self.application.celery_app
         terminate = bool(self.get_argument('terminate', False))
         celery.control.revoke(taskid, terminate=terminate)
@@ -199,8 +199,8 @@ class TaskTimout(ControlHandler):
         hard = hard and float(hard)
         soft = soft and float(soft)
 
-        logging.info("Setting timeouts for '%s' task (%s, %s)" %
-                (taskname, soft, hard))
+        logging.info("Setting timeouts for '%s' task (%s, %s)",
+                     taskname, soft, hard)
         response = celery.control.time_limit(taskname, reply=True,
                                              hard=hard, soft=soft,
                                              destination=[workername])
@@ -226,8 +226,8 @@ class TaskRateLimit(ControlHandler):
         taskname = self.get_argument('taskname', None)
         ratelimit = int(self.get_argument('ratelimit'))
 
-        logging.info("Setting '%s' rate limit for '%s' task" %
-                     (ratelimit, taskname))
+        logging.info("Setting '%s' rate limit for '%s' task",
+                     ratelimit, taskname)
         response = celery.control.rate_limit(taskname,
                                              ratelimit,
                                              reply=True,

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -43,8 +43,8 @@ class TaskAsyncApply(BaseTaskHandler):
         celery = self.application.celery_app
 
         args, kwargs, options = self.get_task_args()
-        logging.debug("Invoking task '%s' with '%s' and '%s'" %
-                     (taskname, args, kwargs))
+        logging.debug("Invoking task '%s' with '%s' and '%s'",
+                      taskname, args, kwargs)
 
         try:
             task = celery.tasks[taskname]

--- a/flower/command.py
+++ b/flower/command.py
@@ -62,11 +62,12 @@ class FlowerCommand(Command):
                         **app_settings)
         atexit.register(flower.stop)
 
-        logging.info('Visit me at http%s://%s:%s' %
-                    ('s' if flower.ssl else '', options.address or 'localhost',
-                     options.port))
+        logging.info('Visit me at http%s://%s:%s',
+                     's' if flower.ssl else '',
+                     options.address or 'localhost',
+                     options.port)
         logging.info('Broker: %s', self.app.connection().as_uri())
-        logging.debug('Settings: %s' % pformat(app_settings))
+        logging.debug('Settings: %s', pformat(app_settings))
 
         try:
             flower.start()

--- a/flower/events.py
+++ b/flower/events.py
@@ -56,7 +56,7 @@ class Events(threading.Thread):
             self._persistent = False
 
         if self._persistent and os.path.exists(db):
-            logging.debug("Loading state from '%s'..." % db)
+            logging.debug("Loading state from '%s'...", db)
             state = shelve.open(self._db)
             self.state = state['events']
             state.close()
@@ -73,7 +73,7 @@ class Events(threading.Thread):
 
     def stop(self):
         if self._persistent:
-            logging.debug("Saving state to '%s'..." % self._db)
+            logging.debug("Saving state to '%s'...", self._db)
             state = shelve.open(self._db)
             state['events'] = self.state
             state.close()
@@ -96,8 +96,8 @@ class Events(threading.Thread):
                 thread.interrupt_main()
             except Exception as e:
                 logging.error("Failed to capture events: '%s', "
-                              "trying again in %s seconds."
-                              % (e, try_interval))
+                              "trying again in %s seconds.",
+                              e, try_interval)
                 logging.debug(e, exc_info=True)
                 time.sleep(try_interval)
 
@@ -108,7 +108,7 @@ class Events(threading.Thread):
         try:
             self._celery_app.control.enable_events()
         except Exception as e:
-            logging.debug("Failed to enable events: '%s'" % e)
+            logging.debug("Failed to enable events: '%s'", e)
 
     def on_event(self, event):
         # Call EventsState.event in ioloop thread to avoid synchronization

--- a/flower/state.py
+++ b/flower/state.py
@@ -46,7 +46,7 @@ class State(threading.Thread):
             transport = None
         if transport and transport not in ('amqp', 'redis', 'mongodb'):
             logging.error("Dashboard and worker management commands are "
-                          "not available for '%s' transport" % transport)
+                          "not available for '%s' transport", transport)
             return
 
         if celery.__version__ < '3.0.0':
@@ -71,34 +71,34 @@ class State(threading.Thread):
                 try_interval *= 2
                 logging.debug('Inspecting workers...')
                 stats = i.stats()
-                logging.debug('Stats: %s' % pformat(stats))
+                logging.debug('Stats: %s', pformat(stats))
                 registered = i.registered()
-                logging.debug('Registered: %s' % pformat(registered))
+                logging.debug('Registered: %s', pformat(registered))
                 scheduled = i.scheduled()
-                logging.debug('Scheduled: %s' % pformat(scheduled))
+                logging.debug('Scheduled: %s', pformat(scheduled))
                 active = i.active()
-                logging.debug('Active: %s' % pformat(active))
+                logging.debug('Active: %s', pformat(active))
                 reserved = i.reserved()
-                logging.debug('Reserved: %s' % pformat(reserved))
+                logging.debug('Reserved: %s', pformat(reserved))
                 revoked = i.revoked()
-                logging.debug('Revoked: %s' % pformat(revoked))
+                logging.debug('Revoked: %s', pformat(revoked))
                 ping = i.ping()
-                logging.debug('Ping: %s' % pformat(ping))
+                logging.debug('Ping: %s', pformat(ping))
                 active_queues = i.active_queues()
-                logging.debug('Active queues: %s' % pformat(active_queues))
+                logging.debug('Active queues: %s', pformat(active_queues))
                 # Inspect.conf was introduced in Celery 3.1
                 conf = hasattr(i, 'conf') and i.conf()
-                logging.debug('Conf: %s' % pformat(conf))
+                logging.debug('Conf: %s', pformat(conf))
 
                 try:
                     if self._broker_api:
                         broker_queues = broker.queues(self.active_queue_names)
                     else:
                         broker_queues = None
-                    logging.debug('Broker queues: %s' % pformat(broker_queues))
+                    logging.debug('Broker queues: %s', pformat(broker_queues))
                 except Exception as e:
                     broker_queues = []
-                    logging.error("Failed to inspect the broker: %s" % e)
+                    logging.error("Failed to inspect the broker: %s", e)
                     logging.debug(e, exc_info=True)
 
                 with self._update_lock:
@@ -125,7 +125,7 @@ class State(threading.Thread):
                 thread.interrupt_main()
             except Exception as e:
                 logging.error("Failed to inspect workers: '%s', trying "
-                              "again in %s seconds" % (e, try_interval))
+                              "again in %s seconds", e, try_interval)
                 logging.debug(e, exc_info=True)
                 time.sleep(try_interval)
 

--- a/flower/views/update.py
+++ b/flower/views/update.py
@@ -48,7 +48,7 @@ class UpdateWorkers(websocket.WebSocketHandler):
         changes = workers.workers
 
         if workers != cls.workers and changes:
-            logging.debug('Sending dashboard updates: %s' % pformat(changes))
+            logging.debug('Sending dashboard updates: %s', pformat(changes))
             for l in cls.listeners:
                 l.write_message(changes)
             cls.workers = workers


### PR DESCRIPTION
The reason why you want to let the logger pass the string formatting arguments is so logging can be grouped properly. Otherwise this happens:

![screen shot 2013-08-12 at 4 32 36 am](https://f.cloud.github.com/assets/48965/944613/1c97f090-02c5-11e3-9d37-d1d3e8477f2e.png)
