### PR TITLE
Fix Unicode/bytes handling for Basic Auth in Py3

### DIFF
--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -65,7 +65,7 @@ class BaseHandler(tornado.web.RequestHandler):
             auth_header = self.request.headers.get("Authorization", "")
             try:
                 basic, credentials = auth_header.split()
-                credentials = b64decode(credentials)
+                credentials = b64decode(credentials.encode()).decode()
                 if basic != 'Basic' or credentials != basic_auth:
                     raise tornado.web.HTTPError(401)
             except ValueError:

--- a/tests/views/test_auth.py
+++ b/tests/views/test_auth.py
@@ -1,0 +1,23 @@
+import base64
+from tests import AsyncHTTPTestCase
+
+
+class AuthTests(AsyncHTTPTestCase):
+    def get_app(self, celery_app=None, events=None, state=None):
+        super(AuthTests, self).get_app(celery_app, events, state)
+        self.app.basic_auth = "hello:world"
+        return self.app
+
+    def test_auth_without_credentials(self):
+        r = self.get('/')
+        self.assertEqual(401, r.code)
+
+    def test_auth_with_bad_credentials(self):
+        credentials = base64.b64encode("not:good".encode()).decode()
+        r = self.get('/', headers={"Authorization": "Basic " + credentials})
+        self.assertEqual(401, r.code)
+
+    def test_auth_with_good_credentials(self):
+        credentials = base64.b64encode("hello:world".encode()).decode()
+        r = self.get('/', headers={"Authorization": "Basic " + credentials})
+        self.assertEqual(200, r.code)


### PR DESCRIPTION
Looks like I missed this one when porting to Python 3 as there weren't any tests for basic auth.

I've added some tests and the very minor change required to get it to work in Python 3 (still OK on 2.6 and 2.7).
