### PR TITLE
Fixed authentication when username or password have URL encoded values

### DIFF
--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -28,8 +28,8 @@ class BrokerBase(object):
         self.host = purl.hostname
         self.port = purl.port
         self.vhost = quote(purl.path[1:], '')
-        self.username = unquote(purl.username)
-        self.password = unquote(purl.password)
+        self.username = unquote(purl.username) if purl.username else purl.username
+        self.password = unquote(purl.password) if purl.password else purl.password
 
     def queues(self, names):
         raise NotImplementedError
@@ -55,8 +55,8 @@ class RabbitMQ(BrokerBase):
             self._broker_api_url += '/'
         url = urljoin(self._broker_api_url, 'queues/' + self.vhost)
         api_url = urlparse(self._broker_api_url)
-        username = unquote(api_url.username or self.username)
-        password = unquote(api_url.password or self.password)
+        username = unquote(api_url.username or '') or self.username
+        password = unquote(api_url.password or '') or self.password
         auth = requests.auth.HTTPBasicAuth(username, password)
         r = requests.get(url, auth=auth)
 


### PR DESCRIPTION
- Some user and/or password might have characters that have to be encoded, such as "@", the `broker-api` config wasn't honouring these values.
