### PR TITLE
Sigterm fix (#137)

### DIFF
--- a/flower/command.py
+++ b/flower/command.py
@@ -33,7 +33,7 @@ define("max_tasks", type=int, default=10000,
 define("db", type=str, default='flower.db', help="flower database file")
 define("persistent", type=bool, default=False, help="enable persistent mode")
 define("broker_api", type=str, default=None,
-        help="inspect broker e.g. http://guest:guest@localhost:15672/api/")
+       help="inspect broker e.g. http://guest:guest@localhost:15672/api/")
 define("certfile", type=str, default=None, help="path to SSL certificate file")
 define("keyfile", type=str, default=None, help="path to SSL key file")
 define("xheaders", type=bool, default=False,


### PR DESCRIPTION
This simply adds a SIGTERM handler when the command line program is created. It calls `sys.exit(0)` which will `raise SystemExit` and cause the `atexit` handler to run as it should.

Ref: #137 
