### PR TITLE
Proposition : Expose custom state of the task in the API

### DIFF
--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -71,6 +71,8 @@ class TaskResult(BaseTaskHandler):
                                  'traceback': result.traceback})
             else:
                 response.update({'result': self.safe_result(result.result)})
+        else:
+            response.update({'meta': result.result})
         self.write(response)
 
     def safe_result(self, result):

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -72,7 +72,7 @@ class TaskResult(BaseTaskHandler):
             else:
                 response.update({'result': self.safe_result(result.result)})
         else:
-            response.update({'meta': result.result})
+            response.update({'meta': self.safe_result(result.result)})
         self.write(response)
 
     def safe_result(self, result):


### PR DESCRIPTION
In my projects, I use custom states:
http://docs.celeryproject.org/en/latest/userguide/tasks.html#custom-states

A `metadata` dict can be provided, and is stored in AsyncResult.result, just like actual results.

This commit exposes the custom state as a `meta` key.

To filter custom states from the actual result, there does not seem to be another way than checking that the result is not `ready()`. The state could be anything, since it can be changed by the user.

I tried to do the same for the `Task` view, but it appears that the `result` is not kept updated....

Thanks for the awesome work !
