### PR TITLE
Adding options to TaskSend

### DIFF
--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -66,7 +66,7 @@ class TaskSend(BaseTaskHandler):
         args, kwargs, options = self.get_task_args()
         logging.debug("Invoking task '%s' with '%s' and '%s'",
                       taskname, args, kwargs)
-        result = celery.send_task(taskname, args=args, kwargs=kwargs)
+        result = celery.send_task(taskname, args=args, kwargs=kwargs, **options)
         response = {'task-id': result.task_id}
         if self.backend_configured(result):
             response.update(state=result.state)


### PR DESCRIPTION
send_task accepts the same parameters as async_apply. 
This allows us to add routing info when using send_task
