### PR TITLE
Added files in static (favicon.ico) as package_data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     classifiers=classifiers,
     packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=['celery', 'tornado'],
-    package_data={'flower': ['templates/*', 'static/**/*']},
+    package_data={'flower': ['templates/*', 'static/**/*', 'static/*.*']},
     entry_points={
         'console_scripts': [
             'flower = flower.__main__:main',


### PR DESCRIPTION
When pip installing flower, `static/favicon.ico` is not copied in (because previously package_data only included files within a subdirectory of static). This results in the error:

```
[E 131218 14:06:15 web:2148] Could not open static file '[rescinded]/lib/python2.7/site-packages/flower/static/favicon.ico'
```

The fix includes any files that are directly contained within the static directory.
