### PR TITLE
Enhancement: Add Tasks API endpoint to return state of the task.

### DIFF
--- a/flower/urls.py
+++ b/flower/urls.py
@@ -63,6 +63,7 @@ handlers = [
     (r"/api/task/async-apply/(.+)", tasks.TaskAsyncApply),
     (r"/api/task/send-task/(.+)", tasks.TaskSend),
     (r"/api/task/result/(.+)", tasks.TaskResult),
+    (r"/api/task/state/(.+)", tasks.TaskState),
     (r"/api/task/timeout/(.+)", control.TaskTimout),
     (r"/api/task/rate-limit/(.+)", control.TaskRateLimit),
     (r"/api/task/revoke/(.+)", control.TaskRevoke),


### PR DESCRIPTION
Because we're already tracking the state of the tasks using events, we should expose it via the API. We've got a bunch of tasks that we spawn with `ignore_result=True` and hence `AsyncResult` always returns `PENDING` for them, and so does the `/api/task/result/` endpoint, however, internally, we're tracking the state of the task, and we can expose it if anyone is interested. 

Willing to do any more work required to get this in. I think at least a few people will find it helpful. :) 
