### PR TITLE
Fix str-bytes mismatch of Google authentication on Python 3

### DIFF
--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -75,10 +75,12 @@ class BaseHandler(tornado.web.RequestHandler):
         if not self.application.auth:
             return True
         user = self.get_secure_cookie('user')
-        if user and re.search(self.application.auth, user):
-            return user
-        else:
-            return
+        if user:
+            if not isinstance(user, str):
+                user = user.decode()
+            if re.search(self.application.auth, user):
+                return user
+        return None
 
     def absolute_url(self, url):
         if settings.URL_PREFIX:


### PR DESCRIPTION
Google authentication was broken on Python 3, because Tornado’s `RequestHandler.get_secure_cookie()` method returns `bytes` instead of `str` on Python 3.  I made it to decode the secured cookie if it’s not a string but a byte array.
