### PR TITLE
adding --basic_auth_file to specify a list of username:login pairs

### DIFF
--- a/flower/app.py
+++ b/flower/app.py
@@ -21,6 +21,7 @@ class Flower(tornado.web.Application):
         self.options = options or object()
         self.auth = getattr(self.options, 'auth', [])
         self.basic_auth = getattr(self.options, 'basic_auth', None)
+        self.basic_auth_file = getattr(self.options, 'basic_auth_file', None)
         self.broker_api = getattr(self.options, 'broker_api', None)
         self.ssl = None
         if options and self.options.certfile and self.options.keyfile:

--- a/flower/command.py
+++ b/flower/command.py
@@ -28,6 +28,8 @@ define("auth", default='', type=str,
        help="regexp  of emails to grant access")
 define("basic_auth", type=str, default=None,
        help="colon separated user-password to enable basic auth")
+define("basic_auth_file", type=str, default=None,
+       help="file containing colon separated user-password (one per line) to enable basic auth")
 define("url_prefix", type=str, help="base url prefix")
 define("max_tasks", type=int, default=10000,
        help="maximum number of tasks to keep in memory (default 10000)")

--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -61,12 +61,19 @@ class BaseHandler(tornado.web.RequestHandler):
     def get_current_user(self):
         # Basic Auth
         basic_auth = self.application.basic_auth
-        if basic_auth:
+        basic_auth_file = self.application.basic_auth_file
+        if basic_auth or basic_auth_file:
             auth_header = self.request.headers.get("Authorization", "")
             try:
                 basic, credentials = auth_header.split()
                 credentials = b64decode(credentials.encode()).decode()
-                if basic != 'Basic' or credentials != basic_auth:
+		basic_auth_list = []
+		if basic_auth_file:
+		    with open(basic_auth_file) as f:
+			basic_auth_list = [x.strip("\r\n") for x in f.readlines()]
+		if basic_auth:
+		    basic_auth_list.append(basic_auth)
+                if basic != 'Basic' or credentials not in basic_auth_list:
                     raise tornado.web.HTTPError(401)
             except ValueError:
                 raise tornado.web.HTTPError(401)


### PR DESCRIPTION
Adding --basic_auth_file to specify a list of username:login pairs that (in addition to the user specified with --basic_auth) are allowed access.
This approach is safer when flower is used in a multiuser environment where other users can see the (--basic_auth) credentials in the process list.
