### PR TITLE
Display error message for failed tasks in result

### DIFF
--- a/flower/models.py
+++ b/flower/models.py
@@ -116,6 +116,7 @@ class TaskModel(BaseModel):
                 continue
             if state and task.state != state:
                 continue
+            task.error_message = [ line for line in task.traceback.split('\n') if line.strip() ][-1]
             yield uuid, task
             i += 1
             if i == limit:

--- a/flower/templates/tasks.html
+++ b/flower/templates/tasks.html
@@ -114,7 +114,13 @@
       </td>
       <td>{{ humanize(task.args, length=20) }}</td>
       <td>{{ humanize(task.kwargs, length=20) }}</td>
-      <td>{{ task.result }}</td>
+      <td>
+        {% if task.state == "FAILURE" %}
+            {{ task.error_message }}
+        {% else %}
+            {{ task.result }}
+        {% end %}
+      </td>
       <td>{{ humanize(task.received, type='time') }}</td>
       <td>{{ humanize(task.started, type='time') }}</td>
     </tr>


### PR DESCRIPTION
It's nice to be able to look at why tasks are failing at a glance
without having to drill down into each individual one
