### PR TITLE
Fix recalculating UTC task times in task monitor

### DIFF
--- a/flower/views/monitor.py
+++ b/flower/views/monitor.py
@@ -22,9 +22,7 @@ class SucceededTaskMonitor(BaseHandler):
 
         data = defaultdict(int)
         for _, task in state.itertasks():
-            utcoffset = getattr(task, 'utcoffset', 0)
-            if (timestamp < (task.timestamp + (utcoffset * 3600))
-                    and task.state == states.SUCCESS):
+            if (timestamp < task.timestamp and task.state == states.SUCCESS):
                 data[task.worker.hostname] += 1
         for worker in state.workers:
             if worker not in data:
@@ -43,9 +41,7 @@ class TimeToCompletionMonitor(BaseHandler):
         queue_time = 0
         num_tasks = 0
         for _, task in state.itertasks():
-            utcoffset = getattr(task, 'utcoffset', 0)
-            if (timestamp < (task.timestamp + (utcoffset * 3600))
-                    and task.state == states.SUCCESS):
+            if (timestamp < task.timestamp and task.state == states.SUCCESS):
                 # eta can make "time in queue" look really scary.
                 if task.eta is not None:
                     continue
@@ -76,9 +72,7 @@ class FailedTaskMonitor(BaseHandler):
 
         data = defaultdict(int)
         for _, task in state.itertasks():
-            utcoffset = getattr(task, 'utcoffset', 0)
-            if (timestamp < (task.timestamp + (utcoffset * 3600))
-                    and task.state == states.FAILURE):
+            if (timestamp < task.timestamp and task.state == states.FAILURE):
                 data[task.worker.hostname] += 1
         for worker in state.workers:
             if worker not in data:


### PR DESCRIPTION
Fixes #257

I believe that `task.timestamp` should not be touched, as everything is in UTC now.

Need someone who knows the project better, to verify if my assumptions are correct. I know the code fixes the issue, but maybe introduces other bugs, which I'm not aware of.

See https://github.com/mher/flower/issues/257#issuecomment-52766817 for details
