### PR TITLE
Add requirement for Celery >= 2.5.0

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
-celery
+celery>=2.5.0
 tornado>=3.2.0
 babel


### PR DESCRIPTION
Below 2.5.0 running flower fails with "AttributeError: 'App' object has no attribute 'tasks'" at line 154 of command.py.
