### PR TITLE
Fix missing requirements in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ recursive-include docs *
 recursive-include flower/static *
 recursive-include flower/templates *
 recursive-include tests *
+recursive-include requirements *.txt


### PR DESCRIPTION
I think requirements/*.txt is missing in manifest file, our pypi build fails when trying to build flower because it cannot find requirements/default.txt...
