### PR TITLE
wakeup workers so initial list is populated

### DIFF
--- a/flower/events.py
+++ b/flower/events.py
@@ -103,7 +103,7 @@ class Events(threading.Thread):
                     recv = EventReceiver(conn,
                                          handlers={"*": self.on_event},
                                          app=self.capp)
-                    recv.capture(limit=None, timeout=None)
+                    recv.capture(limit=None, timeout=None, wakeup=True)
 
                 try_interval = 1
             except (KeyboardInterrupt, SystemExit):


### PR DESCRIPTION
With the current master I am facing two problems, one being that at startup the dashboard shows no workers and the other being that what workers do show up (after receiving some task for example) they soon are marked 'offline'. These problems I believe are related to this [celery issue](https://github.com/celery/celery/issues/2272), for which I proposed a fix. However I believe the first problem, i.e. no workers at startup, should be fixed additionally in flower by passing the `wakeup` argument to the `EventReceiver.capture` method. This will make sure that all workers send a heartbeat once flower starts.
