### PR TITLE
fix for when broker returns no messages on startup

### DIFF
--- a/flower/views/monitor.py
+++ b/flower/views/monitor.py
@@ -98,6 +98,6 @@ class BrokerMonitor(BaseHandler):
 
         data = defaultdict(int)
         for queue in queues:
-            data[queue['name']] = queue['messages']
+            data[queue['name']] = queue.get('messages', 0)
 
         self.write(data)


### PR DESCRIPTION
Sometimes my RabbitMQ server doesn't return all the expected keys in it's response, possibly because the values are zero. Here is the exception I get in the log:

```
[E 140923 08:32:03 web:1407] Uncaught exception GET /monitor/broker (127.0.0.1)
    HTTPServerRequest(protocol='http', host='celery.longaccess.io', method='GET', uri='/monitor/broker', version='HTTP/1.1', remote_ip='127.0.0.1', headers={'Accept-Language': 'en-US,en;q=0.8,el;q=0.6', 'Accept-Encoding': 'gzip,deflate', 'X-Requested-With': 'XMLHttpRequest', 'Host': 'celery.longaccess.io', 'Accept': '*/*', 'User-Agent': 'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.120 Safari/537.36', 'Connection': 'upgrade', 'Referer': 'https://celery.longaccess.io/monitor', 'Cookie': 'user="2|1:0|10:1411461120|4:user|24:a2tAbG9uZ2FjY2Vzcy5jb20=|9b1f9e2d9c7fa3b13843e5305d9f92e1a5ff234a159fd5d6636f91ba39758a0d"', 'If-None-Match': '"98ea1c919cc9b14826071bda9946984bcaa66201"'})
    Traceback (most recent call last):
      File "/var/www/deepfreeze.io/env/lib/python2.7/site-packages/tornado/web.py", line 1334, in _execute
        result = yield result
      File "/var/www/deepfreeze.io/env/lib/python2.7/site-packages/tornado/gen.py", line 628, in run
        value = future.result()
      File "/var/www/deepfreeze.io/env/lib/python2.7/site-packages/tornado/concurrent.py", line 109, in result
        raise_exc_info(self._exc_info)
      File "/var/www/deepfreeze.io/env/lib/python2.7/site-packages/tornado/gen.py", line 633, in run
        yielded = self.gen.send(value)
      File "/home/kouk/flower/flower/views/monitor.py", line 101, in get
        data[queue['name']] = queue['messages']
    KeyError: 'messages'
```
