### PR TITLE
Fix seeing worker details when authentication is enabled

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,5 @@ Rob Hoelz
 Tadej Janež
 Corey Farwell
 Thomas Grainger
+Samuel Cormier-Iijima
+


### PR DESCRIPTION
This issue happens because the request is made without any credentials, so the API endpoint returns an unauthorized response. By using the controller directly, an HTTP round trip is avoided as well.
