### PR TITLE
Fixing typo in the auth documentation.

### DIFF
--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -36,7 +36,7 @@ with a Google account. Google OAuth 2.0 authentication is enabled using the
 
 For instance, if you want to grant access to `me@gmail.com` and `you@gmail.com`: ::
 
-    $ celery flower --auth="me@gmail.com|you@gmail.com" --oauth2_key=... --oauth2_secret=... --auth2_redirect_uri=http://flower.example.com/login
+    $ celery flower --auth="me@gmail.com|you@gmail.com" --oauth2_key=... --oauth2_secret=... --oauth2_redirect_uri=http://flower.example.com/login
 
 Alternatively you can set environment variables instead of command line arguments: ::
 


### PR DESCRIPTION
oauth2_redirect_uri was missing an 'o'
