### PR TITLE
Fixing retry interval reset on connection failure

### DIFF
--- a/flower/events.py
+++ b/flower/events.py
@@ -108,9 +108,9 @@ class Events(threading.Thread):
                     recv = EventReceiver(conn,
                                          handlers={"*": self.on_event},
                                          app=self.capp)
+                    try_interval = 1
                     recv.capture(limit=None, timeout=None, wakeup=True)
 
-                try_interval = 1
             except (KeyboardInterrupt, SystemExit):
                 try:
                     import _thread as thread


### PR DESCRIPTION
Retry intervals were not getting reset on connection success. As such, intermittent failures in connectivity would each take longer to retry even if there was a successful connection made between them.