### PR TITLE
Humanize the "Failed" datetime

### DIFF
--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -69,7 +69,7 @@
                 <tr>
                   <td>{{ humanize(name) }}</td>
                   <td>
-                    {% if name in ['sent', 'received', 'started', 'succeeded', 'retried', 'timestamp'] %}
+                    {% if name in ['sent', 'received', 'started', 'succeeded', 'retried', 'timestamp', 'failed'] %}
                     {{ humanize(getattr(task, name, None), type='time') }}
                     {% elif name == 'worker' %}
                     <a


### PR DESCRIPTION
The "failed" datetime is now humanized, instead of having to decypher a timestamp.