### PR TITLE
Fix bug in handling denied emails with OAuth

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,3 +49,4 @@ David Matson
 Paulo SantAnna
 Sanchit Arora
 Ilya Lebedev
+Wendy Liu

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -39,11 +39,11 @@ class LoginHandler(BaseHandler, tornado.auth.GoogleOAuth2Mixin):
             headers={'Authorization': 'Bearer %s' % access_token})
         email = json.loads(response.body.decode('utf-8'))['emails'][0]['value']
         if not re.match(self.application.options.auth, email):
-            raise tornado.web.HTTPError(
-                404,
-                "Access denied to '{email}'. "
-                "Please use another account or ask your admin to "
-                "add your email to flower --auth".format(**user))
+            message = (
+                "Access denied to '{email}'. Please use another account or "
+                "ask your admin to add your email to flower --auth."
+            ).format(email=email)
+            raise tornado.web.HTTPError(404, message)
 
         self.set_secure_cookie("user", str(email))
 


### PR DESCRIPTION
With Google OAuth, when a user tries to log in with an email that isn't allowed, a KeyError is triggered in line 46 of flower/views/auth.py because the `user` dictionary does not have an `email` and so the call to `format()` doesn't work. Changing the kwargs to `email=email` fixes that.

I also replaced the HTTPError exception with a call to `self.render()`, because the former does not appear to display any information to the user (causing the request to simply hang) while the latter does. I'm not sure if this is what 404.html is intended for, but it works perfectly for me.

Thanks for your work on flower!