### PR TITLE
Enable WebSocket CORS

### DIFF
--- a/flower/options.py
+++ b/flower/options.py
@@ -55,6 +55,8 @@ define("natural_time", type=bool, default=True,
        help="show time in relative format")
 define("tasks_columns", type=str, default="name,uuid,state,args,kwargs,result,received,started",
        help="Slugs of columns on /tasks/ page, delimited by comma")
+define("ws_allowed_hosts", type=str, default=None, multiple=True,
+       help="List of CORS enabled host:port")
 
 # deprecated options
 define("url_prefix", type=str, help="base url prefix")

--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -539,11 +539,27 @@ var flower = (function () {
         return results && results[1] || 0;
     };
 
+    function querystring(qs) {
+        return qs ? qs.substr(1).split('&').map(
+            function(v){
+                return v.split('=');
+            }
+        ).reduce(
+            function(prev, curr) {
+                prev[curr[0]] = curr[1];
+                return prev;
+            },
+        {}) : {};
+    }
+
+
     $(document).ready(function () {
         if ($.inArray($(location).attr('pathname'), ['/', '/dashboard']) != -1) {
-            var host = $(location).attr('host'),
+            var qs = querystring($(location).attr('search')),
+                host = $(location).attr('host'),
+                port = qs.wsport ? ':' + qs.wsport : '',
                 protocol = $(location).attr('protocol') == 'http:' ? 'ws://' : 'wss://',
-                ws = new WebSocket(protocol + host + "/update-dashboard");
+                ws = new WebSocket(protocol + host + port + "/update-dashboard");
             ws.onmessage = function (event) {
                 var update = $.parseJSON(event.data);
                 on_dashboard_update(update);

--- a/flower/templates/broker.html
+++ b/flower/templates/broker.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="broker") %}
+  {% module Template("navbar.html", active_tab="broker", wsport=wsport) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/dashboard.html
+++ b/flower/templates/dashboard.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="dashboard") %}
+  {% module Template("navbar.html", active_tab="dashboard", wsport=wsport) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/monitor.html
+++ b/flower/templates/monitor.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="monitor") %}
+  {% module Template("navbar.html", active_tab="monitor", wsport=wsport) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/navbar.html
+++ b/flower/templates/navbar.html
@@ -9,10 +9,10 @@
       <a class="brand" href="/">Celery Flower</a>
       <div class="nav-collapse">
         <ul class="nav">
-            <li {% if active_tab == "dashboard" %}class="active"{% end %}><a href="/dashboard">Dashboard</a></li>
-            <li {% if active_tab == "tasks" %}class="active"{% end %}><a href="/tasks?limit=100">Tasks</a></li>
-            <li {% if active_tab == "broker" %}class="active"{% end %}><a href="/broker">Broker</a></li>
-            <li {% if active_tab == "monitor" %}class="active"{% end %}><a href="/monitor">Monitor</a></li>
+            <li {% if active_tab == "dashboard" %}class="active"{% end %}><a href="/dashboard{% if wsport %}?wsport={{wsport}}{% end %}">Dashboard</a></li>
+            <li {% if active_tab == "tasks" %}class="active"{% end %}><a href="/tasks?limit=100{% if wsport %}&wsport={{wsport}}{% end %}">Tasks</a></li>
+            <li {% if active_tab == "broker" %}class="active"{% end %}><a href="/broker{% if wsport %}?wsport={{wsport}}{% end %}">Broker</a></li>
+            <li {% if active_tab == "monitor" %}class="active"{% end %}><a href="/monitor{% if wsport %}?wsport={{wsport}}{% end %}">Monitor</a></li>
           <li><a href="http://flower.readthedocs.org" target="_blank">Docs</a></li>
           <li><a href="https://github.com/mher/flower" target="_blank">Code</a></li>
         </ul>

--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="tasks") %}
+  {% module Template("navbar.html", active_tab="tasks", wsport=wsport) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/tasks.html
+++ b/flower/templates/tasks.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="tasks") %}
+  {% module Template("navbar.html", active_tab="tasks", wsport=wsport) %}
 {% end %}
 
 {% block extra_styles %}

--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="workers") %}
+  {% module Template("navbar.html", active_tab="workers", wsport=wsport) %}
 {% end %}
 
 {% block container %}

--- a/flower/views/broker.py
+++ b/flower/views/broker.py
@@ -18,6 +18,7 @@ class BrokerView(BaseHandler):
     @gen.coroutine
     def get(self):
         app = self.application
+        wsport = self.get_argument('wsport', default=None, type=int)
 
         http_api = None
         if app.transport == 'amqp' and app.options.broker_api:
@@ -30,4 +31,5 @@ class BrokerView(BaseHandler):
 
         self.render("broker.html",
                     broker_url=app.capp.connection().as_uri(),
-                    queues=queues)
+                    queues=queues,
+                    wsport=wsport)

--- a/flower/views/monitor.py
+++ b/flower/views/monitor.py
@@ -14,7 +14,8 @@ from ..api.control import ControlHandler
 class Monitor(BaseHandler):
     @web.authenticated
     def get(self):
-        self.render("monitor.html")
+        wsport = self.get_argument('wsport', default=None, type=int)
+        self.render("monitor.html", wsport=wsport)
 
 
 class SucceededTaskMonitor(BaseHandler):

--- a/flower/views/tasks.py
+++ b/flower/views/tasks.py
@@ -18,10 +18,11 @@ class TaskView(BaseHandler):
     @web.authenticated
     def get(self, task_id):
         task = get_task_by_id(self.application.events, task_id)
+        wsport = self.get_argument('wsport', default=None, type=int)
         if task is None:
             raise web.HTTPError(404, "Unknown task '%s'" % task_id)
 
-        self.render("task.html", task=task)
+        self.render("task.html", task=task, wsport=wsport)
 
 
 class TasksView(BaseHandler):
@@ -38,6 +39,7 @@ class TasksView(BaseHandler):
         received_end = self.get_argument('received-end', None)
         started_start = self.get_argument('started-start', None)
         started_end = self.get_argument('started-end', None)
+        wsport = self.get_argument('wsport', default=None, type=int)
 
         worker = worker if worker != 'All' else None
         type = type if type != 'All' else None
@@ -76,6 +78,7 @@ class TasksView(BaseHandler):
             started_end=started_end,
             params=params,
             time=time,
+            wsport=wsport,
         )
 
     def format_task(self, args):

--- a/flower/views/workers.py
+++ b/flower/views/workers.py
@@ -12,6 +12,7 @@ class WorkerView(BaseHandler):
     @gen.coroutine
     def get(self, name):
         refresh = self.get_argument('refresh', default=False, type=bool)
+        wsport  = self.get_argument('wsport', default=None, type=int)
 
         if refresh:
             yield ListWorkers.update_workers(app=self.application, workername=name)
@@ -26,4 +27,4 @@ class WorkerView(BaseHandler):
                 "Unable to get stats for '%s' worker" % name
             )
 
-        self.render("worker.html", worker=dict(worker, name=name))
+        self.render("worker.html", worker=dict(worker, name=name), wsport=wsport)


### PR DESCRIPTION
This commit allows flower to run websocket server listening on a different port than http does, from a client point of view.

This scenario is found when running flower from inside [OpenShift](github.com/openshift/origin-server), where websocket conections are expected on port 8000 instead 80. This causes `tornado.websocket.WebSocketHandler` to fail because method `check_origin`'s default behavior is to allow connections only for matching `Host` and `Origin` HTTP headers.

One can now explicitly specify what are the accepted hosts for websocket connections through option `ws_allowed_hosts`:

    $ flower --ws_allowed_hosts=http://flower-caruccio.getup.io