### PR TITLE
Enable WebSocket CORS

### DIFF
--- a/flower/options.py
+++ b/flower/options.py
@@ -55,6 +55,8 @@ define("natural_time", type=bool, default=True,
        help="show time in relative format")
 define("tasks_columns", type=str, default="name,uuid,state,args,kwargs,result,received,started",
        help="Slugs of columns on /tasks/ page, delimited by comma")
+define("ws_allowed_hosts", type=str, default=None, multiple=True,
+       help="List of CORS enabled host:port")
 
 # deprecated options
 define("url_prefix", type=str, help="base url prefix")

--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -539,11 +539,27 @@ var flower = (function () {
         return results && results[1] || 0;
     };
 
+    function querystring(qs) {
+        return qs ? qs.substr(1).split('&').map(
+            function(v){
+                return v.split('=');
+            }
+        ).reduce(
+            function(prev, curr) {
+                prev[curr[0]] = curr[1];
+                return prev;
+            },
+        {}) : {};
+    }
+
+
     $(document).ready(function () {
         if ($.inArray($(location).attr('pathname'), ['/', '/dashboard']) != -1) {
-            var host = $(location).attr('host'),
+            var qs = querystring($(location).attr('search')),
+                host = $(location).attr('host'),
+                port = qs.wsport ? ':' + qs.wsport : '',
                 protocol = $(location).attr('protocol') == 'http:' ? 'ws://' : 'wss://',
-                ws = new WebSocket(protocol + host + "/update-dashboard");
+                ws = new WebSocket(protocol + host + port + "/update-dashboard");
             ws.onmessage = function (event) {
                 var update = $.parseJSON(event.data);
                 on_dashboard_update(update);

--- a/flower/templates/base.html
+++ b/flower/templates/base.html
@@ -36,7 +36,7 @@
 
   <body>
     {% block navbar %}
-    {% module Template("navbar.html", active_tab="") %}
+    {% module Template("navbar.html", active_tab="", wsport=wsport) %}
     {% end %}
 
     <div class="container-fluid">

--- a/flower/templates/broker.html
+++ b/flower/templates/broker.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="broker") %}
+  {% module Template("navbar.html", active_tab="broker", wsport=wsport) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/dashboard.html
+++ b/flower/templates/dashboard.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="dashboard") %}
+  {% module Template("navbar.html", active_tab="dashboard", wsport=wsport) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/monitor.html
+++ b/flower/templates/monitor.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="monitor") %}
+  {% module Template("navbar.html", active_tab="monitor", wsport=wsport) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/navbar.html
+++ b/flower/templates/navbar.html
@@ -9,10 +9,10 @@
       <a class="brand" href="/">Celery Flower</a>
       <div class="nav-collapse">
         <ul class="nav">
-            <li {% if active_tab == "dashboard" %}class="active"{% end %}><a href="/dashboard">Dashboard</a></li>
-            <li {% if active_tab == "tasks" %}class="active"{% end %}><a href="/tasks?limit=100">Tasks</a></li>
-            <li {% if active_tab == "broker" %}class="active"{% end %}><a href="/broker">Broker</a></li>
-            <li {% if active_tab == "monitor" %}class="active"{% end %}><a href="/monitor">Monitor</a></li>
+            <li {% if active_tab == "dashboard" %}class="active"{% end %}><a href="/dashboard{% if wsport %}?wsport={{wsport}}{% end %}">Dashboard</a></li>
+            <li {% if active_tab == "tasks" %}class="active"{% end %}><a href="/tasks?limit=100{% if wsport %}&wsport={{wsport}}{% end %}">Tasks</a></li>
+            <li {% if active_tab == "broker" %}class="active"{% end %}><a href="/broker{% if wsport %}?wsport={{wsport}}{% end %}">Broker</a></li>
+            <li {% if active_tab == "monitor" %}class="active"{% end %}><a href="/monitor{% if wsport %}?wsport={{wsport}}{% end %}">Monitor</a></li>
           <li><a href="http://flower.readthedocs.org" target="_blank">Docs</a></li>
           <li><a href="https://github.com/mher/flower" target="_blank">Code</a></li>
         </ul>

--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="tasks") %}
+  {% module Template("navbar.html", active_tab="tasks", wsport=wsport) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/tasks.html
+++ b/flower/templates/tasks.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="tasks") %}
+  {% module Template("navbar.html", active_tab="tasks", wsport=wsport) %}
 {% end %}
 
 {% block extra_styles %}

--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="workers") %}
+  {% module Template("navbar.html", active_tab="workers", wsport=wsport) %}
 {% end %}
 
 {% block container %}

--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -17,6 +17,8 @@ class BaseHandler(tornado.web.RequestHandler):
         functions = self._get_template_functions()
         assert not set(map(lambda x: x[0], functions)) & set(kwargs.keys())
         kwargs.update(functions)
+        if 'wsport' not in kwargs:
+            kwargs['wsport'] = self.get_argument('wsport', default=None, type=int)
         super(BaseHandler, self).render(*args, **kwargs)
 
     def write_error(self, status_code, **kwargs):

--- a/flower/views/dashboard.py
+++ b/flower/views/dashboard.py
@@ -8,6 +8,11 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
+try:
+    from urllib.parse import urlparse  # py2
+except ImportError:
+    from urlparse import urlparse  # py3
+
 from tornado import web
 from tornado import gen
 from tornado import websocket
@@ -50,6 +55,19 @@ class DashboardUpdateHandler(websocket.WebSocketHandler):
     periodic_callback = None
     workers = None
     page_update_interval = 2000
+    ws_allowed_hosts = None
+
+    def __init__(self, *va, **kva):
+        super(DashboardUpdateHandler, self).__init__(*va, **kva)
+        app = self.application
+        if app.options.ws_allowed_hosts is not None:
+            self.ws_allowed_hosts = [ urlparse(host).netloc for host in app.options.ws_allowed_hosts ]
+
+    def check_origin(self, origin):
+        if not self.ws_allowed_hosts:
+            return super(DashboardUpdateHandler, self).check_origin(origin)
+        parsed_origin = urlparse(origin)
+        return parsed_origin.netloc in self.ws_allowed_hosts
 
     def open(self):
         app = self.application


### PR DESCRIPTION
This commit allows flower to run websocket server listening on a different port than http does, from a client point of view.

This scenario is found when running flower from inside [OpenShift](github.com/openshift/origin-server), where websocket conections are expected on port 8000 instead 80. This causes `tornado.websocket.WebSocketHandler` to fail because method `check_origin`'s default behavior is to allow connections only for matching `Host` and `Origin` HTTP headers.

One can now explicitly specify what are the accepted hosts for websocket connections through option `ws_allowed_hosts`:

```
$ flower --ws_allowed_hosts=http://flower-caruccio.getup.io
```
