### PR TITLE
Making Dashboard Accessible

### DIFF
--- a/flower/utils/__init__.py
+++ b/flower/utils/__init__.py
@@ -14,13 +14,17 @@ def gen_cookie_secret():
 def bugreport(app=None):
     try:
         import celery
+        from celery.app import set_default_app
         import tornado
         import babel
+
+        set_default_app(app)
+
         return 'flower   -> flower:%s tornado:%s babel:%s%s' % (
             __version__,
             tornado.version,
             babel.__version__,
-            celery.bugreport(app)
+            celery.bugreport()
         )
     except (ImportError, AttributeError):
         return 'Unknown Celery version'

--- a/flower/views/dashboard.py
+++ b/flower/views/dashboard.py
@@ -107,5 +107,5 @@ class DashboardUpdateHandler(websocket.WebSocketHandler):
                 failed=failed,
                 succeeded=succeeded,
                 retried=retried,
-                loadavg=worker.loadavg)
+                loadavg=getattr(worker, 'loadavg', None))
         return workers


### PR DESCRIPTION
Fixes #373

`celery==3.0.23` doesn't have a `loadavg` attribute on the worker, so people running anything lower than the current version of celery will see "N/A" under the Load Avg. table column.

Other than that, this makes the Dashboard accessible again for users not on the newest version of `celery`.

Side note... When running the test suite, I needed to `pip install futures` (it's not in any requirements files and when it isn't installed running `python -m tests` raises `/Users/mikehelmick/.virtualenv/flower/bin/python: No module named concurrent.futures; 'tests' is a package and cannot be directly executed`)