### PR TITLE
Don't use lstrip when removing ENV_VAR_PREFIX in the flower command

### DIFF
--- a/flower/command.py
+++ b/flower/command.py
@@ -32,7 +32,7 @@ class FlowerCommand(Command):
         env_options = filter(lambda x: x.startswith(self.ENV_VAR_PREFIX),
                              os.environ)
         for env_var_name in env_options:
-            name = env_var_name.lstrip(self.ENV_VAR_PREFIX).lower()
+            name = env_var_name.replace(self.ENV_VAR_PREFIX, '', 1).lower()
             value = os.environ[env_var_name]
             option = options._options[name]
             if option.multiple:


### PR DESCRIPTION
Don't use lstrip when removing ENV\_VAR\_PREFIX in the flower command. lstrip removes all occurrences of the given characters at the beginning of a string, it does not treat these characters as a substring. We need to remove the substring "FLOWER_", not the characters "F", "L", "O", "W", "E", "R", "\_". For example, given "FLOWER\_", lstip will remove "FLOWER\_O" from "FLOWER\_OAUTH2\_SECRET", but only "FLOWER\_" should be removed.