### PR TITLE
Avoid KeyError when using FLOWER_ prefix

### DIFF
--- a/flower/command.py
+++ b/flower/command.py
@@ -34,12 +34,13 @@ class FlowerCommand(Command):
         for env_var_name in env_options:
             name = env_var_name.replace(self.ENV_VAR_PREFIX, '', 1).lower()
             value = os.environ[env_var_name]
-            option = options._options[name]
-            if option.multiple:
-                value = map(option.type, value.split(','))
-            else:
-                value = option.type(value)
-            setattr(options, name, value)
+            if name in options._options:
+                option = options._options[name]
+                if option.multiple:
+                    value = map(option.type, value.split(','))
+                else:
+                    value = option.type(value)
+                setattr(options, name, value)
 
         argv = list(filter(self.flower_option, argv))
         # parse the command line to get --conf option


### PR DESCRIPTION
I use FLOWER_HOST as environment variable but flower try to set it causing 

    Traceback (most recent call last):
      File "/usr/local/bin/flower", line 9, in <module>
        load_entry_point('flower==0.8.2', 'console_scripts', 'flower')()
      File "/usr/local/lib/python2.7/dist-packages/flower/__main__.py", line 11, in main
        flower.execute_from_commandline()
      File "/usr/local/lib/python2.7/dist-packages/celery/bin/base.py", line 311, in execute_from_commandline
        return self.handle_argv(self.prog_name, argv[1:])
      File "/usr/local/lib/python2.7/dist-packages/flower/command.py", line 98, in handle_argv
        return self.run_from_argv(prog_name, argv)
      File "/usr/local/lib/python2.7/dist-packages/flower/command.py", line 37, in run_from_argv
        option = options._options[name]
    KeyError: 'host'

I just added a check to be sure that the key is available in options.