### PR TITLE
Allow other (external) login handlers

### DIFF
--- a/flower/command.py
+++ b/flower/command.py
@@ -63,10 +63,10 @@ class FlowerCommand(Command):
             enable_pretty_logging()
 
         if options.auth:
-            settings[GoogleOAuth2Mixin._OAUTH_SETTINGS_KEY] = {
-                'key': options.oauth2_key or os.environ.get('FLOWER_GOOGLE_OAUTH2_KEY'),
-                'secret': options.oauth2_secret or os.environ.get('FLOWER_GOOGLE_OAUTH2_SECRET'),
-                'redirect_uri': options.oauth2_redirect_uri or os.environ.get('FLOWER_GOOGLE_OAUTH2_REDIRECT_URI'),
+            settings['oauth'] = {
+                'key': options.oauth2_key or os.environ.get('FLOWER_OAUTH2_KEY'),
+                'secret': options.oauth2_secret or os.environ.get('FLOWER_OAUTH2_SECRET'),
+                'redirect_uri': options.oauth2_redirect_uri or os.environ.get('FLOWER_AUTH2_REDIRECT_URI'),
             }
 
         if options.certfile and options.keyfile:

--- a/flower/options.py
+++ b/flower/options.py
@@ -22,11 +22,11 @@ define("auth", default='', type=str,
 define("basic_auth", type=str, default=None, multiple=True,
        help="enable http basic authentication")
 define("oauth2_key", type=str, default=None,
-       help="Google oauth2 key (requires --auth)")
+       help="OAuth2 key (requires --auth)")
 define("oauth2_secret", type=str, default=None,
-       help="Google oauth2 secret (requires --auth)")
+       help="OAuth2 secret (requires --auth)")
 define("oauth2_redirect_uri", type=str, default=None,
-       help="Google oauth2 redirect uri (requires --auth)")
+       help="OAuth2 redirect uri (requires --auth)")
 define("max_tasks", type=int, default=10000,
        help="maximum number of tasks to keep in memory")
 define("db", type=str, default='flower',

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -16,6 +16,8 @@ from ..views import BaseHandler
 
 
 class GoogleAuth2LoginHandler(BaseHandler, tornado.auth.GoogleOAuth2Mixin):
+    _OAUTH_SETTINGS_KEY = 'oauth'
+
     @tornado.web.asynchronous
     def get(self):
         redirect_uri = self.settings[self._OAUTH_SETTINGS_KEY]['redirect_uri']
@@ -65,7 +67,7 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
     _OAUTH_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
     _OAUTH_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
     _OAUTH_NO_CALLBACKS = False
-    _OAUTH_SETTINGS_KEY = 'google_oauth'
+    _OAUTH_SETTINGS_KEY = 'oauth'
 
     @tornado.auth._auth_return_future
     def get_authenticated_user(self, redirect_uri, code, callback):

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
-import re
 import json
+import functools
+import re
+import urllib as urllib_parse
 
 import tornado.web
 import tornado.auth
@@ -56,6 +58,85 @@ class GoogleAuth2LoginHandler(BaseHandler, tornado.auth.GoogleOAuth2Mixin):
 class LoginHandler(BaseHandler):
     def __new__(cls, *args, **kwargs):
         return instantiate(options.auth_provider, *args, **kwargs)
+
+
+class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
+
+    _OAUTH_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+    _OAUTH_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+    _OAUTH_NO_CALLBACKS = False
+    _OAUTH_SETTINGS_KEY = 'google_oauth'
+
+    @tornado.auth._auth_return_future
+    def get_authenticated_user(self, redirect_uri, code, callback):
+        http = self.get_auth_http_client()
+        body = urllib_parse.urlencode({
+            "redirect_uri": redirect_uri,
+            "code": code,
+            "client_id": self.settings[self._OAUTH_SETTINGS_KEY]['key'],
+            "client_secret": self.settings[self._OAUTH_SETTINGS_KEY]['secret'],
+            "grant_type": "authorization_code",
+        })
+
+        http.fetch(
+            self._OAUTH_ACCESS_TOKEN_URL,
+            functools.partial(self._on_access_token, callback),
+            method="POST",
+            headers={'Content-Type': 'application/x-www-form-urlencoded', 'Accept': 'application/json'}, body=body)
+
+    @tornado.web.asynchronous
+    def _on_access_token(self, future, response):
+        if response.error:
+            future.set_exception(tornado.auth.AuthError('OAuth authentication error: %s' % str(response)))
+            return
+
+        future.set_result(json.loads(response.body))
+
+    def get_auth_http_client(self):
+        return httpclient.AsyncHTTPClient()
+
+    @tornado.web.asynchronous
+    def get(self):
+        redirect_uri = self.settings[self._OAUTH_SETTINGS_KEY]['redirect_uri']
+        if self.get_argument('code', False):
+            self.get_authenticated_user(
+                redirect_uri=redirect_uri,
+                code=self.get_argument('code'),
+                callback=self._on_auth,
+            )
+        else:
+            self.authorize_redirect(
+                redirect_uri=redirect_uri,
+                client_id=self.settings[self._OAUTH_SETTINGS_KEY]['key'],
+                scope=['user:email'],
+                response_type='code',
+                extra_params={'approval_prompt': 'auto'}
+            )
+
+    @tornado.web.asynchronous
+    def _on_auth(self, user):
+        if not user:
+            raise tornado.web.HTTPError(500, 'OAuth authentication failed')
+        access_token = user['access_token']
+
+        req = httpclient.HTTPRequest('https://api.github.com/user/emails',
+                                     headers={'Authorization': 'token ' + access_token, 'User-agent': 'Tornado auth'})
+        response = httpclient.HTTPClient().fetch(req)
+
+        emails = {email['email'].lower() for email in json.loads(response.body.decode('utf-8'))
+                  if email['verified'] and re.match(self.application.options.auth, email['email'])}
+
+        if not emails:
+            message = (
+                "Access denied. Please use another account or "
+                "ask your admin to add your email to flower --auth."
+            )
+            raise tornado.web.HTTPError(403, message)
+
+        self.set_secure_cookie("user", str(emails.pop()))
+
+        next_ = self.get_argument('next', '/')
+        self.redirect(next_)
 
 
 class LogoutHandler(BaseHandler):


### PR DESCRIPTION
I guess we're probably not the only ones wanting to integrate Flower authentication with our own app's. The current Google-only OAuth2 mechanism doesn't help in that regard.

This patch allows authentication to be performed by a different Python package. It is the simples solution I could find. Maybe not the optimal one, but I'm available to improve it if needed.

Said package would have to specify the following in its `setup.py`:

```python
# [...]
    entry_points={'flower.auth_providers': {'login_handler = another_package:GithubLoginHandler'}}
# [...]
```