### PR TITLE
bugfix: remove deprectated url_prefix method in ajax call

### DIFF
--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -283,7 +283,7 @@ var flower = (function () {
 
         $.ajax({
             type: 'POST',
-            url: url_prefix() + '/api/task/timeout/' + taskname,
+            url: '/api/task/timeout/' + taskname,
             dataType: 'json',
             data: {
                 'workername': workername,


### PR DESCRIPTION
Fixed js runtime error below:
![image](https://cloud.githubusercontent.com/assets/829810/8435641/c60ba99a-1f52-11e5-868d-15309ed96daf.png)
