### PR TITLE
fixes #424

### DIFF
--- a/flower/utils/tasks.py
+++ b/flower/utils/tasks.py
@@ -41,7 +41,7 @@ def iter_tasks(events, limit=None, type=None, worker=None, state=None,
         if started_end and task.started and\
                 task.started > convert(started_end):
             continue
-        if not satisfies_search_terms(task, any_value_search_term, result_search_term, kwargs_search_terms):
+        if not satisfies_search_terms(task, any_value_search_term, result_search_term, args_search_terms, kwargs_search_terms):
             continue
         yield uuid, task
         i += 1

--- a/flower/utils/tasks.py
+++ b/flower/utils/tasks.py
@@ -20,6 +20,7 @@ def iter_tasks(events, limit=None, type=None, worker=None, state=None,
     )
     any_value_search_term = search_terms.get('any', None)
     result_search_term = search_terms.get('result', None)
+    args_search_terms = search_terms.get('args', None)
     kwargs_search_terms = search_terms.get('kwargs', None)
 
     for uuid, task in tasks:


### PR DESCRIPTION
the signature for satisfies_search_terms() has changed from 4 args to 5 args, updating the call

Fixes this exception:

Traceback (most recent call last):
2015-07-17T01:57:08.395606+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/tornado/web.py", line 1413, in execute
2015-07-17T01:57:08.395607+00:00 app[web.1]: result = method(self.path_args, *self.path_kwargs)
2015-07-17T01:57:08.395609+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/tornado/web.py", line 2717, in wrapper
2015-07-17T01:57:08.395610+00:00 app[web.1]: return method(self, args, *kwargs)
2015-07-17T01:57:08.395612+00:00 app[web.1]: File "/app/.heroku/src/flower/flower/views/tasks.py", line 88, in get
2015-07-17T01:57:08.395613+00:00 app[web.1]: search=search
2015-07-17T01:57:08.395615+00:00 app[web.1]: File "/app/.heroku/src/flower/flower/views/__init_.py", line 20, in render
2015-07-17T01:57:08.395617+00:00 app[web.1]: super(BaseHandler, self).render(args, *kwargs)
2015-07-17T01:57:08.395618+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/tornado/web.py", line 704, in render
2015-07-17T01:57:08.395620+00:00 app[web.1]: html = self.render_string(template_name, kwargs)
2015-07-17T01:57:08.395621+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/tornado/web.py", line 811, in render_string
2015-07-17T01:57:08.395622+00:00 app[web.1]: return t.generate(namespace)
2015-07-17T01:57:08.395624+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/tornado/template.py", line 278, in generate
2015-07-17T01:57:08.395625+00:00 app[web.1]: return execute()
2015-07-17T01:57:08.395626+00:00 app[web.1]: File "tasks_html.generated.py", line 225, in _tt_execute
2015-07-17T01:57:08.395628+00:00 app[web.1]: for uuid, task in tasks: # tasks.html:151 (via base.html:49)
2015-07-17T01:57:08.395629+00:00 app[web.1]: File "/app/.heroku/src/flower/flower/utils/tasks.py", line 44, in iter_tasks
2015-07-17T01:57:08.395630+00:00 app[web.1]: if not satisfies_search_terms(task, any_value_search_term, result_search_term, kwargs_search_terms):
2015-07-17T01:57:08.395632+00:00 app[web.1]: TypeError: satisfies_search_terms() takes exactly 5 arguments (4 given)