### PR TITLE
returning temporary result during task progress

### DIFF
--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -307,8 +307,8 @@ Get a task result
         if not self.backend_configured(result):
             raise HTTPError(503)
         response = {'task-id': taskid, 'state': result.state}
-        if result.ready():
-            self.update_response_result(response, result)
+
+        self.update_response_result(response, result)
         self.write(response)
 
 class GetQueueLengths(BaseTaskHandler):


### PR DESCRIPTION
Conflicts:
	flower/api/tasks.py

This is a cherry pick from the change I tested on 0.8. untested after this conflict resolution.

The point here is that a celery task can return temporary results ( via [update_state()](http://celery.readthedocs.org/en/latest/reference/celery.app.task.html#celery.app.task.Task.update_state) and maybe passing a custom state ) with some data in result, and that it is useful to be able to retrieve this data while the task is still ongoing... => we do not need to wait for ready().

Let me know if I should make more changes...