### PR TITLE
Make sure Babel is at least 1.0

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 celery>=3.1.0
 tornado>=4.0.0
-babel
+babel>=1.0
 pytz

--- a/tests/api/test_control.py
+++ b/tests/api/test_control.py
@@ -34,7 +34,12 @@ class WorkerControlTests(AsyncHTTPTestCase):
         celery.control.broadcast = MagicMock(return_value=[{'test': 'ok'}])
         r = self.post('/api/worker/pool/restart/test', body={})
         self.assertEqual(200, r.code)
-        celery.control.broadcast.assert_called_once()
+        celery.control.broadcast.assert_called_once_with(
+            'pool_restart',
+            arguments={'reload': False},
+            destination=['test'],
+            reply=True,
+        )
 
     def test_pool_grow(self):
         celery = self._app.capp


### PR DESCRIPTION
`babel.dates.format_timedelta` is supported only on babel-1.0 onward, see their [release notes](http://babel.pocoo.org/docs/changelog/#version-1-0).

Besides, updated a test to use `assert_called_once_with`, given that `assert_called_once` is no longer supported in [Python 3's mock](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock).