### PR TITLE
Add back support for --url_prefix

### DIFF
--- a/flower/app.py
+++ b/flower/app.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+import re
 
 from functools import partial
 from concurrent.futures import ThreadPoolExecutor
@@ -11,7 +12,7 @@ import tornado.web
 from tornado import ioloop
 
 from .api import control
-from .urls import handlers
+from .urls import get_handlers
 from .events import Events
 from .options import default_options
 
@@ -25,9 +26,10 @@ class Flower(tornado.web.Application):
 
     def __init__(self, options=None, capp=None, events=None,
                  io_loop=None, **kwargs):
-        kwargs.update(handlers=handlers)
+        options = options or default_options
+        kwargs.update(handlers=get_handlers(options.url_prefix))
         super(Flower, self).__init__(**kwargs)
-        self.options = options or default_options
+        self.options = options
         self.io_loop = io_loop or ioloop.IOLoop.instance()
         self.ssl_options = kwargs.get('ssl_options', None)
 

--- a/flower/command.py
+++ b/flower/command.py
@@ -55,7 +55,9 @@ class FlowerCommand(Command):
             settings['cookie_secret'] = options.cookie_secret
 
         if options.url_prefix:
-            logger.error('url_prefix option is not supported anymore')
+            options.url_prefix = options.url_prefix.rstrip('/')
+            settings['static_url_prefix'] = options.url_prefix + '/static/'
+            settings['login_url'] = options.url_prefix + '/login/'
 
         if options.debug and options.logging == 'info':
             options.logging = 'debug'

--- a/flower/options.py
+++ b/flower/options.py
@@ -59,9 +59,9 @@ define("tasks_columns", type=str, default="name,uuid,state,args,kwargs,result,re
        help="Slugs of columns on /tasks/ page, delimited by comma")
 define("auth_provider", default='flower.views.auth.GoogleAuth2LoginHandler',
        help="auth handler class")
+define("url_prefix", type=str, help="base url prefix")
 
 # deprecated options
-define("url_prefix", type=str, help="base url prefix")
 define("inspect", default=False, help="inspect workers", type=bool)
 
 default_options = options

--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -3,6 +3,19 @@ var flower = (function () {
     /*jslint browser: true */
     /*global $, WebSocket, jQuery, Rickshaw */
 
+    function escape_regex(str) {
+        return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+    }
+
+    function prefix_uri(uri) {
+        return FLOWER_URL_PREFIX + uri;
+    }
+
+    function unprefix_uri(uri) {
+        var prefix_regex = new RegExp('^' + escape_regex(uri));
+        return uri.replace(prefix_regex, '');
+    }
+
     function on_alert_close(event) {
         event.preventDefault();
         event.stopPropagation();
@@ -52,7 +65,7 @@ var flower = (function () {
 
             $.ajax({
                 type: 'POST',
-                url: '/api/worker/shutdown/' + worker_name,
+                url: prefix_uri('/api/worker/shutdown/' + worker_name),
                 dataType: 'json',
                 data: { workername: worker_name },
                 success: function (data) {
@@ -75,7 +88,7 @@ var flower = (function () {
 
             $.ajax({
                 type: 'POST',
-                url: '/api/worker/pool/restart/' + worker_name,
+                url: prefix_uri('/api/worker/pool/restart/' + worker_name),
                 dataType: 'json',
                 data: { workername: worker_name },
                 success: function (data) {
@@ -94,7 +107,7 @@ var flower = (function () {
         if (!$selected_workers.length) {
             $.ajax({
                 type: 'GET',
-                url: '/api/workers',
+                url: prefix_uri('/api/workers'),
                 data: { refresh: 1 },
                 success: function (data) {
                     show_success_alert('Refreshed');
@@ -111,7 +124,7 @@ var flower = (function () {
 
             $.ajax({
                 type: 'GET',
-                url: '/api/workers',
+                url: prefix_uri('/api/workers'),
                 dataType: 'json',
                 data: { workername: unescape(worker_name), refresh: 1 },
                 success: function (data) {
@@ -151,7 +164,7 @@ var flower = (function () {
 
         $.ajax({
             type: 'POST',
-            url: '/api/worker/pool/grow/' + workername,
+            url: prefix_uri('/api/worker/pool/grow/' + workername),
             dataType: 'json',
             data: {
                 'workername': workername,
@@ -175,7 +188,7 @@ var flower = (function () {
 
         $.ajax({
             type: 'POST',
-            url: '/api/worker/pool/shrink/' + workername,
+            url: prefix_uri('/api/worker/pool/shrink/' + workername),
             dataType: 'json',
             data: {
                 'workername': workername,
@@ -200,7 +213,7 @@ var flower = (function () {
 
         $.ajax({
             type: 'POST',
-            url: '/api/worker/pool/autoscale/' + workername,
+            url: prefix_uri('/api/worker/pool/autoscale/' + workername),
             dataType: 'json',
             data: {
                 'workername': workername,
@@ -225,7 +238,7 @@ var flower = (function () {
 
         $.ajax({
             type: 'POST',
-            url: '/api/worker/queue/add-consumer/' + workername,
+            url: prefix_uri('/api/worker/queue/add-consumer/' + workername),
             dataType: 'json',
             data: {
                 'workername': workername,
@@ -234,7 +247,7 @@ var flower = (function () {
             success: function (data) {
                 show_success_alert(data.message);
                 setTimeout(function () {
-                    $('#tab-queues').load('/worker/' + workername + ' #tab-queues').fadeIn('show');
+                    $('#tab-queues').load(prefix_uri('/worker/' + workername + ' #tab-queues')).fadeIn('show');
                 }, 10000);
             },
             error: function (data) {
@@ -252,7 +265,7 @@ var flower = (function () {
 
         $.ajax({
             type: 'POST',
-            url: '/api/worker/queue/cancel-consumer/' + workername,
+            url: prefix_uri('/api/worker/queue/cancel-consumer/' + workername),
             dataType: 'json',
             data: {
                 'workername': workername,
@@ -261,7 +274,7 @@ var flower = (function () {
             success: function (data) {
                 show_success_alert(data.message);
                 setTimeout(function () {
-                    $('#tab-queues').load('/worker/' + workername + ' #tab-queues').fadeIn('show');
+                    $('#tab-queues').load(prefix_uri('/worker/' + workername + ' #tab-queues')).fadeIn('show');
                 }, 10000);
             },
             error: function (data) {
@@ -283,7 +296,7 @@ var flower = (function () {
 
         $.ajax({
             type: 'POST',
-            url: '/api/task/timeout/' + taskname,
+            url: prefix_uri('/api/task/timeout/' + taskname),
             dataType: 'json',
             data: {
                 'workername': workername,
@@ -310,7 +323,7 @@ var flower = (function () {
 
         $.ajax({
             type: 'POST',
-            url: '/api/task/rate-limit/' + taskname,
+            url: prefix_uri('/api/task/rate-limit/' + taskname),
             dataType: 'json',
             data: {
                 'workername': workername,
@@ -319,7 +332,7 @@ var flower = (function () {
             success: function (data) {
                 show_success_alert(data.message);
                 setTimeout(function () {
-                    $('#tab-limits').load('/worker/' + workername + ' #tab-limits').fadeIn('show');
+                    $('#tab-limits').load(prefix_uri('/worker/' + workername + ' #tab-limits')).fadeIn('show');
                 }, 10000);
             },
             error: function (data) {
@@ -336,7 +349,7 @@ var flower = (function () {
 
         $.ajax({
             type: 'POST',
-            url: '/api/task/revoke/' + taskid,
+            url: prefix_uri('/api/task/revoke/' + taskid),
             dataType: 'json',
             data: {
                 'terminate': false,
@@ -358,7 +371,7 @@ var flower = (function () {
 
         $.ajax({
             type: 'POST',
-            url: '/api/task/revoke/' + taskid,
+            url: prefix_uri('/api/task/revoke/' + taskid),
             dataType: 'json',
             data: {
                 'terminate': true,
@@ -384,7 +397,7 @@ var flower = (function () {
             if (tr.length === 0) {
                 $('#workers-table-row').clone().removeClass('hidden').attr('id', id).appendTo('tbody');
                 tr = $('#' + sel);
-                tr.children('td').children('a').attr('href', '/worker/' + name).text(name);
+                tr.children('td').children('a').attr('href', prefix_uri('/worker/' + name)).text(name);
             }
 
             var stat = tr.children('td:eq(2)').children(),
@@ -541,10 +554,11 @@ var flower = (function () {
     };
 
     $(document).ready(function () {
-        if ($.inArray($(location).attr('pathname'), ['/', '/dashboard']) != -1) {
+        var uri = unprefix_uri($(location).attr('pathname'));
+        if ($.inArray(uri, ['/', '/dashboard']) != -1) {
             var host = $(location).attr('host'),
                 protocol = $(location).attr('protocol') == 'http:' ? 'ws://' : 'wss://',
-                ws = new WebSocket(protocol + host + "/update-dashboard");
+                ws = new WebSocket(protocol + host + prefix_uri("/update-dashboard"));
             ws.onmessage = function (event) {
                 var update = $.parseJSON(event.data);
                 on_dashboard_update(update);
@@ -567,7 +581,7 @@ var flower = (function () {
             });
         });
 
-        if ($(location).attr('pathname') === '/monitor') {
+        if (uri === '/monitor') {
             var sts = current_unix_time(),
                 fts = current_unix_time(),
                 tts = current_unix_time(),
@@ -579,7 +593,7 @@ var flower = (function () {
 
             $.ajax({
                 type: 'GET',
-                url: '/monitor/succeeded-tasks',
+                url: prefix_uri('/monitor/succeeded-tasks'),
                 data: {lastquery: current_unix_time()},
                 success: function (data) {
                     succeeded_graph = create_graph(data, '-succeeded');
@@ -588,7 +602,7 @@ var flower = (function () {
                     succeeded_graph.series.setTimeInterval(updateinterval);
                     setInterval(function () {
                         update_graph(succeeded_graph,
-                                     '/monitor/succeeded-tasks',
+                                     prefix_uri('/monitor/succeeded-tasks'),
                                      sts);
                         sts = current_unix_time();
                     }, updateinterval);
@@ -598,7 +612,7 @@ var flower = (function () {
 
             $.ajax({
                 type: 'GET',
-                url: '/monitor/completion-time',
+                url: prefix_uri('/monitor/completion-time'),
                 data: {lastquery: current_unix_time()},
                 success: function (data) {
                     time_graph = create_graph(data, '-time', null, null,  's');
@@ -607,7 +621,7 @@ var flower = (function () {
                     time_graph.series.setTimeInterval(updateinterval);
                     setInterval(function () {
                         update_graph(time_graph,
-                                     '/monitor/completion-time',
+                                     prefix_uri('/monitor/completion-time'),
                                      tts);
                         tts = current_unix_time();
                     }, updateinterval);
@@ -617,7 +631,7 @@ var flower = (function () {
 
             $.ajax({
                 type: 'GET',
-                url: '/monitor/failed-tasks',
+                url: prefix_uri('/monitor/failed-tasks'),
                 data: {lastquery: current_unix_time()},
                 success: function (data) {
                     failed_graph = create_graph(data, '-failed');
@@ -626,7 +640,7 @@ var flower = (function () {
                     failed_graph.series.setTimeInterval(updateinterval);
                     setInterval(function () {
                         update_graph(failed_graph,
-                                     '/monitor/failed-tasks',
+                                     prefix_uri('/monitor/failed-tasks'),
                                      fts);
                         fts = current_unix_time();
                     }, updateinterval);
@@ -636,7 +650,7 @@ var flower = (function () {
 
             $.ajax({
                 type: 'GET',
-                url: '/monitor/broker',
+                url: prefix_uri('/monitor/broker'),
                 success: function (data) {
                     broker_graph = create_graph(data, '-broker');
                     broker_graph.update();
@@ -644,7 +658,7 @@ var flower = (function () {
                     broker_graph.series.setTimeInterval(updateinterval);
                     setInterval(function () {
                         update_graph(broker_graph,
-                                     '/monitor/broker');
+                                     prefix_uri('/monitor/broker'));
                     }, updateinterval);
 
                 },

--- a/flower/templates/base.html
+++ b/flower/templates/base.html
@@ -36,7 +36,7 @@
 
   <body>
     {% block navbar %}
-    {% module Template("navbar.html", active_tab="") %}
+    {% module Template("navbar.html", active_tab="", prefix_uri=prefix_uri) %}
     {% end %}
 
     <div class="container-fluid">
@@ -73,6 +73,9 @@
     <script src="{{ static_url('js/rickshaw.min.js') }}"></script>
     <script src="{{ static_url('js/bootstrap-datetimepicker.min.js') }}"></script>
 
+    <script type="text/javascript">
+        var FLOWER_URL_PREFIX = '{{ url_prefix or '' }}';
+    </script>
     <script src="{{ static_url('js/flower.js') }}"></script>
 
     {% block extra_scripts %}

--- a/flower/templates/broker.html
+++ b/flower/templates/broker.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="broker") %}
+  {% module Template("navbar.html", active_tab="broker", prefix_uri=prefix_uri) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/dashboard.html
+++ b/flower/templates/dashboard.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="dashboard") %}
+  {% module Template("navbar.html", active_tab="dashboard", prefix_uri=prefix_uri) %}
 {% end %}
 
 {% block container %}
   <div class="container-fluid">
     <div class="btn-group btn-group-justified">
-        <a id="btn-active" class="btn btn-default btn-large" href="/tasks?limit=100&amp;state=STARTED">Active: {{ sum(map(lambda x:x.get('active') or 0, workers.values() )) }}</a>
-        <a id="btn-processed" class="btn btn-default btn-large" href="/tasks?limit=100">Processed: {{ sum(map(lambda x:x.get('task-received') or 0, workers.values() )) }}</a>
-        <a id="btn-failed" class="btn btn-default btn-large" href="/tasks?limit=100&amp;state=FAILURE">Failed: {{ sum(map(lambda x:x.get('task-failed') or 0, workers.values() )) }}</a>
-        <a id="btn-succeeded" class="btn btn-default btn-large" href="/tasks?limit=100&amp;state=SUCCESS">Succeeded: {{ sum(map(lambda x:x.get('task-succeeded') or 0, workers.values() )) }}</a>
-        <a id="btn-retried" class="btn btn-default btn-large" href="/tasks?limit=100&amp;state=RETRY">Retried: {{ sum(map(lambda x:x.get('task-retried') or 0, workers.values() )) }}</a>
+        <a id="btn-active" class="btn btn-default btn-large" href="{{ prefix_uri('/tasks?limit=100&amp;state=STARTED') }}">Active: {{ sum(map(lambda x:x.get('active') or 0, workers.values() )) }}</a>
+        <a id="btn-processed" class="btn btn-default btn-large" href={{ prefix_uri('/tasks?limit=100') }}>Processed: {{ sum(map(lambda x:x.get('task-received') or 0, workers.values() )) }}</a>
+        <a id="btn-failed" class="btn btn-default btn-large" href="{{ prefix_uri('/tasks?limit=100&amp;state=FAILURE') }}">Failed: {{ sum(map(lambda x:x.get('task-failed') or 0, workers.values() )) }}</a>
+        <a id="btn-succeeded" class="btn btn-default btn-large" href="{{ prefix_uri('/tasks?limit=100&amp;state=SUCCESS') }}">Succeeded: {{ sum(map(lambda x:x.get('task-succeeded') or 0, workers.values() )) }}</a>
+        <a id="btn-retried" class="btn btn-default btn-large" href="{{ prefix_uri('/tasks?limit=100&amp;state=RETRY') }}">Retried: {{ sum(map(lambda x:x.get('task-retried') or 0, workers.values() )) }}</a>
     </div>
 
     <div class="panel panel-default">
@@ -61,7 +61,7 @@
       {% for name, info in workers.items() %}
       <tr id="{{ url_escape(name) }}">
         <td class="is_selected"><input type="checkbox"></td>
-        <td><a href="{{ '/worker/' + name }}">{{ name }}</a></td>
+        <td><a href="{{ prefix_uri('/worker/' + name) }}">{{ name }}</a></td>
         <td>
           {% if info.get('status', None) %}
           <span class="label label-success">Online</span>

--- a/flower/templates/monitor.html
+++ b/flower/templates/monitor.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="monitor") %}
+  {% module Template("navbar.html", active_tab="monitor", prefix_uri=prefix_uri) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/navbar.html
+++ b/flower/templates/navbar.html
@@ -6,13 +6,13 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </a>
-      <a class="brand" href="/">Celery Flower</a>
+      <a class="brand" href="{{ prefix_uri('/') }}">Celery Flower</a>
       <div class="nav-collapse collapse">
         <ul class="nav">
-            <li {% if active_tab == "dashboard" %}class="active"{% end %}><a href="/dashboard">Dashboard</a></li>
-            <li {% if active_tab == "tasks" %}class="active"{% end %}><a href="/tasks?limit=100">Tasks</a></li>
-            <li {% if active_tab == "broker" %}class="active"{% end %}><a href="/broker">Broker</a></li>
-            <li {% if active_tab == "monitor" %}class="active"{% end %}><a href="/monitor">Monitor</a></li>
+            <li {% if active_tab == "dashboard" %}class="active"{% end %}><a href="{{ prefix_uri('/dashboard') }}">Dashboard</a></li>
+            <li {% if active_tab == "tasks" %}class="active"{% end %}><a href="{{ prefix_uri('/tasks?limit=100') }}">Tasks</a></li>
+            <li {% if active_tab == "broker" %}class="active"{% end %}><a href="{{ prefix_uri('/broker') }}">Broker</a></li>
+            <li {% if active_tab == "monitor" %}class="active"{% end %}><a href="{{ prefix_uri('/monitor') }}">Monitor</a></li>
         </ul>
         <ul class="nav pull-right">
           <li><a href="http://flower.readthedocs.org" target="_blank">Docs</a></li>

--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="tasks") %}
+  {% module Template("navbar.html", active_tab="tasks", prefix_uri=prefix_uri) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/tasks.html
+++ b/flower/templates/tasks.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-{% module Template("navbar.html", active_tab="tasks") %}
+{% module Template("navbar.html", active_tab="tasks", prefix_uri=prefix_uri) %}
 {% end %}
 
 {% block extra_styles %}
@@ -34,7 +34,7 @@
       </div>
       <div id="task-filter-form-container" class="accordion-body in collapse">
         <div class="accordion-inner" style="padding-left: 0; padding-right: 0;">
-          <form id="task-filter-form" class="form-horizontal" action="/tasks" method="GET">
+          <form id="task-filter-form" class="form-horizontal" action="{{ prefix_uri('/tasks') }}" method="GET">
             <div class="filter-column left">
               <div class="control-group">
                 <label class="control-label" for="input-limit">Limit:</label>

--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="workers") %}
+  {% module Template("navbar.html", active_tab="workers", prefix_uri=prefix_uri) %}
 {% end %}
 
 {% block container %}
@@ -200,7 +200,7 @@
                 {% for task in worker.get('active', {}) %}
                     <tr>
                       <td>{{ task['name'] }}</td>
-                      <td><a href="{{ '/task/' + task['id'] }}">{{ task['id'] }}</a></td>
+                      <td><a href="{{ prefix_uri('/task/' + task['id']) }}">{{ task['id'] }}</a></td>
                       <td>{{ humanize(task['time_start'], type='time') }}</td>
                       <td>{{ task['acknowledged'] }}</td>
                       <td>{{ task['worker_pid'] }}</td>
@@ -225,7 +225,7 @@
                 {% for task in worker.get('scheduled', {}) %}
                     <tr>
                       <td>{{ task['request']['name'] }}</td>
-                      <td><a href="{{ '/task/' + task['request']['id'] }}">{{ task['request']['id'] }}</a></td>
+                      <td><a href="{{ prefix_uri('/task/' + task['request']['id']) }}">{{ task['request']['id'] }}</a></td>
                       <td>{{ task['request']['args'] }}</td>
                       <td>{{ task['request']['kwargs'] }}</td>
                     </tr>
@@ -247,7 +247,7 @@
                 {% for task in worker.get('reserved', {}) %}
                     <tr>
                       <td>{{ task['name'] }}</td>
-                      <td><a href="{{ '/task/' + task['id'] }}">{{ task['id'] }}</a></td>
+                      <td><a href="{{ prefix_uri('/task/' + task['id']) }}">{{ task['id'] }}</a></td>
                       <td>{{ task['args'] }}</td>
                       <td>{{ task['kwargs'] }}</td>
                     </tr>
@@ -265,7 +265,7 @@
                 <tbody>
                   {% for task in worker.get('revoked', []) %}
                     <tr>
-                      <td><a href="{{ '/task/' + task }}">{{ task }}</a></td>
+                      <td><a href="{{ prefix_uri('/task/' + task) }}">{{ task }}</a></td>
                     </tr>
                   {% end %}
                 </tbody>

--- a/flower/urls.py
+++ b/flower/urls.py
@@ -25,8 +25,7 @@ settings = dict(
     login_url='/login',
 )
 
-
-handlers = [
+app_handlers = [
     # App
     (r"/", DashboardView),
     (r"/dashboard", DashboardView),
@@ -78,7 +77,20 @@ handlers = [
     # Auth
     (r"/login", auth.LoginHandler),
     (r"/logout", auth.LogoutHandler),
+]
 
+error_handlers = [
     # Error
     (r".*", NotFoundErrorHandler),
 ]
+
+handlers = app_handlers + error_handlers
+
+
+def get_handlers(url_prefix):
+    if url_prefix:
+        def prefix_uri(t):
+            return tuple((url_prefix + t[0],) + t[1:])
+        return map(prefix_uri, app_handlers) + error_handlers
+    else:
+        return handlers

--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -17,7 +17,14 @@ class BaseHandler(tornado.web.RequestHandler):
         functions = self._get_template_functions()
         assert not set(map(lambda x: x[0], functions)) & set(kwargs.keys())
         kwargs.update(functions)
+        kwargs['url_prefix'] = self.application.options.url_prefix
+        kwargs['prefix_uri'] = self.prefix_uri
         super(BaseHandler, self).render(*args, **kwargs)
+
+    def prefix_uri(self, uri):
+        if self.application.options.url_prefix:
+            uri = self.application.options.url_prefix + uri
+        return uri
 
     def write_error(self, status_code, **kwargs):
         if status_code in (404, 403):


### PR DESCRIPTION
This PR adds back the `--url_prefix` option. It modifies the routes to include the URL prefix, so a proper nginx config would look simply like:

```nginx
server {
    # ...
    location /flower/ {
        # no "rewrite /flower/(.*) /$1 break;" line
        proxy_pass http://localhost:5555;
    }
}
```

And run flower with:

```bash
flower --url_prefix=/flower/
```