### PR TITLE
Add received and started in API list tasks

### DIFF
--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -435,6 +435,10 @@ List tasks
         worker = self.get_argument('workername', None)
         type = self.get_argument('taskname', None)
         state = self.get_argument('state', None)
+        received_start = self.get_argument('received-start', None)
+        received_end = self.get_argument('received-end', None)
+        started_start = self.get_argument('started-start', None)
+        started_end = self.get_argument('started-end', None)
 
         limit = limit and int(limit)
         worker = worker if worker != 'All' else None
@@ -444,7 +448,9 @@ List tasks
         result = []
         for task_id, task in tasks.iter_tasks(
                 app.events, limit=limit, type=type,
-                worker=worker, state=state):
+                worker=worker, state=state,
+                received_start=received_start, received_end=received_end,
+                started_start=started_start, started_end=started_end):
             task = task.as_dict()
             task.pop('worker')
             result.append((task_id, task))

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -439,6 +439,7 @@ List tasks
         received_end = self.get_argument('received-end', None)
         started_start = self.get_argument('started-start', None)
         started_end = self.get_argument('started-end', None)
+        task_id = self.get_argument('task-id', None)
 
         limit = limit and int(limit)
         worker = worker if worker != 'All' else None
@@ -450,7 +451,8 @@ List tasks
                 app.events, limit=limit, type=type,
                 worker=worker, state=state,
                 received_start=received_start, received_end=received_end,
-                started_start=started_start, started_end=started_end):
+                started_start=started_start, started_end=started_end,
+                task_id=task_id):
             task = task.as_dict()
             task.pop('worker')
             result.append((task_id, task))

--- a/flower/utils/tasks.py
+++ b/flower/utils/tasks.py
@@ -10,7 +10,8 @@ from .search import satisfies_search_terms
 
 def iter_tasks(events, limit=None, type=None, worker=None, state=None,
                sort_by=None, received_start=None, received_end=None,
-               started_start=None, started_end=None, search_terms=None):
+               started_start=None, started_end=None, search_terms=None,
+               task_id=None):
     i = 0
     tasks = events.state.tasks_by_timestamp()
     if sort_by is not None:
@@ -25,6 +26,8 @@ def iter_tasks(events, limit=None, type=None, worker=None, state=None,
     kwargs_search_terms = search_terms.get('kwargs', None)
 
     for uuid, task in tasks:
+        if task_id and uuid != task_id:
+            continue
         if type and task.name != type:
             continue
         if worker and task.worker and task.worker.hostname != worker:


### PR DESCRIPTION
When working with API, received and started parameters filter tasks by dates.

Example:

``` html
http://localhost:5555/api/tasks?received-start=2015-12-28 23:00
http://localhost:5555/api/tasks?received-start=2015-12-28 23:00&received-end=2015-12-29 23:00
```

Also you could search a task by UUID (if exist or not) without call request info uri.

Example:

``` html
http://localhost:5555/api/tasks?task-id=ada92cb7-8c4e-4b29-8f63-05660ccc3ad1
```
