### PR TITLE
enable --url-prefix option

### DIFF
--- a/flower/command.py
+++ b/flower/command.py
@@ -60,7 +60,7 @@ class FlowerCommand(Command):
             settings['cookie_secret'] = options.cookie_secret
 
         if options.url_prefix:
-            logger.error('url_prefix option is not supported anymore')
+            settings['url_prefix'] = options.url_prefix
 
         if options.debug and options.logging == 'info':
             options.logging = 'debug'

--- a/flower/urls.py
+++ b/flower/urls.py
@@ -82,3 +82,21 @@ handlers = [
     # Error
     (r".*", NotFoundErrorHandler),
 ]
+
+def make_handlers(handlers, prefix=None):
+    if prefix is None:
+        return handlers
+    rv = []
+    for h in handlers:
+        regex = h[0]
+        hdl = h[1]
+        if regex.startswith('/'):
+            regex = prefix + regex
+
+        if hdl == StaticFileHandler:
+            args = h[2]
+            rv.append((regex, hdl, args,))
+            continue
+        rv.append((regex, hdl,))
+
+    return rv


### PR DESCRIPTION
Any other convenient way to prefix Tornado app?

I need to prefix flower app to a certain path ,  say `http://example.com/flower`.