### PR TITLE
`events.Task.as_dict` is new in Celery 3.1.7

### DIFF
--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -445,8 +445,9 @@ List tasks
         for task_id, task in tasks.iter_tasks(
                 app.events, limit=limit, type=type,
                 worker=worker, state=state):
-            task = task.as_dict()
-            task.pop('worker')
+            task = tasks.as_dict(task)
+            if 'worker' in task:
+                task.pop('worker')
             result.append((task_id, task))
         self.write(dict(result))
 

--- a/flower/utils/tasks.py
+++ b/flower/utils/tasks.py
@@ -72,3 +72,12 @@ def get_task_by_id(events, task_id):
         if task is not None:
             task._fields = _fields
         return task
+
+
+def as_dict(task):
+    # as_dict is new in Celery 3.1.7
+    if hasattr(Task, 'as_dict'):
+        return task.as_dict()
+    # old version
+    else:
+        return task.info(fields=task._defaults.keys())

--- a/flower/views/dashboard.py
+++ b/flower/views/dashboard.py
@@ -46,7 +46,24 @@ class DashboardView(BaseHandler):
 
     @classmethod
     def _as_dict(cls, worker):
-        return dict((k, worker.__getattribute__(k)) for k in worker._fields)
+        if hasattr(worker, '_fields'):
+            return dict((k, worker.__getattribute__(k)) for k in worker._fields)
+        else:
+            return cls._info(worker)
+
+    @classmethod
+    def _info(cls, worker):
+        _fields = ('hostname', 'pid', 'freq', 'heartbeats', 'clock',
+                   'active', 'processed', 'loadavg', 'sw_ident',
+                   'sw_ver', 'sw_sys')
+
+        def _keys():
+            for key in _fields:
+                value = getattr(worker, key, None)
+                if value is not None:
+                    yield key, value
+
+        return dict(_keys())
 
 
 class DashboardUpdateHandler(websocket.WebSocketHandler):


### PR DESCRIPTION
`events.Task.as_dict` is new in Celery 3.1.7

```
[E 160115 16:39:43 web:1524] Uncaught exception GET /api/tasks (127.0.0.1)
   Traceback (most recent call last):
      File "/Users/ken/.virtualenvs/test2/lib/python2.7/site-packages/tornado/web.py", line 1443, in _execute
        result = method(*self.path_args, **self.path_kwargs)
      File "/Users/ken/.virtualenvs/test2/lib/python2.7/site-packages/tornado/web.py", line 2800, in wrapper
        return method(self, *args, **kwargs)
      File "/Users/ken/tx/flower/flower/api/tasks.py", line 448, in get
        task = task.as_dict()
      File "/Users/ken/.virtualenvs/test2/lib/python2.7/site-packages/celery/datastructures.py", line 353, in __getattr__
        type(self).__name__, k))
    AttributeError: 'Task' object has no attribute 'as_dict'
```

fix that