### PR TITLE
Add option to set unix_socket permissions

### DIFF
--- a/flower/app.py
+++ b/flower/app.py
@@ -52,7 +52,8 @@ class Flower(tornado.web.Application):
         else:
             from tornado.netutil import bind_unix_socket
             server = HTTPServer(self)
-            socket = bind_unix_socket(self.options.unix_socket)
+            mode = int(self.options.unix_socket_mode or '600', 8)  # octal value
+            socket = bind_unix_socket(self.options.unix_socket, mode=mode)
             server.add_socket(socket)
 
         self.io_loop.add_future(

--- a/flower/app.py
+++ b/flower/app.py
@@ -26,7 +26,7 @@ class Flower(tornado.web.Application):
 
     def __init__(self, options=None, capp=None, events=None,
                  io_loop=None, **kwargs):
-        kwargs.update(handlers=handlers)
+        kwargs.update(handlers=self.get_handlers())
         super(Flower, self).__init__(**kwargs)
         self.options = options or default_options
         self.io_loop = io_loop or ioloop.IOLoop.instance()
@@ -40,6 +40,11 @@ class Flower(tornado.web.Application):
             io_loop=self.io_loop,
             max_tasks_in_memory=self.options.max_tasks)
         self.started = False
+
+    @classmethod
+    def get_handlers(cls):
+        # This method can be overridden in derived classes
+        return handlers
 
     def start(self):
         self.pool = self.pool_executor_cls(max_workers=self.max_workers)

--- a/flower/command.py
+++ b/flower/command.py
@@ -32,6 +32,11 @@ logger = logging.getLogger(__name__)
 class FlowerCommand(Command):
     ENV_VAR_PREFIX = 'FLOWER_'
 
+    @classmethod
+    def get_flower_class(cls):
+        # This method can be overridden in derived classes
+        return Flower
+
     def run_from_argv(self, prog_name, argv=None, **_kwargs):
         env_options = filter(lambda x: x.startswith(self.ENV_VAR_PREFIX),
                              os.environ)
@@ -84,7 +89,8 @@ class FlowerCommand(Command):
                 settings['ssl_options']['ca_certs'] = abs_path(options.ca_certs)
 
         self.app.loader.import_default_modules()
-        flower = Flower(capp=self.app, options=options, **settings)
+        flower_class = self.get_flower_class()
+        flower = flower_class(capp=self.app, options=options, **settings)
         atexit.register(flower.stop)
 
         def sigterm_handler(signal, frame):

--- a/flower/options.py
+++ b/flower/options.py
@@ -15,6 +15,8 @@ define("address", default='',
        help="run on the given address", type=str)
 define("unix_socket", default='',
        help="Path to unix socket to bind", type=str)
+define("unix_socket_mode", default='600',
+       help="Unix permissions to unix socket (oct value)", type=str)
 define("debug", default=False,
        help="run in debug mode", type=bool)
 define("inspect_timeout", default=1000, type=float,


### PR DESCRIPTION
By default Tornado creates a socket file with 600 permission flags. But running behind of nginx there is an "Access Denied" error as nginx might work under different user.
I am going to use it with 666 permission flag and hope it would be useful for others.
