### PR TITLE
Add max_workers option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -185,6 +185,13 @@ keyfile
 
 A path to SSL key file
 
+.. _max_workers:
+
+max_workers
+~~~~~~~~~
+
+Maximum number of workers to keep in memory (by default, `max_workers=5000`)
+
 .. _max_tasks:
 
 max_tasks

--- a/docs/man.rst
+++ b/docs/man.rst
@@ -58,6 +58,8 @@ OPTIONS
   --inspect_timeout                inspect timeout (in milliseconds) (default
                                    *1000*)
   --keyfile                        path to SSL key file
+  --max_workrs                     maximum number of workers to keep in memory
+                                   (default *5000*)
   --max_tasks                      maximum number of tasks to keep in memory
                                    (default *10000*)
   --persistent                     enable persistent mode (default *False*)

--- a/flower/app.py
+++ b/flower/app.py
@@ -38,6 +38,7 @@ class Flower(tornado.web.Application):
             persistent=self.options.persistent,
             enable_events=self.options.enable_events,
             io_loop=self.io_loop,
+            max_workers_in_memory=self.options.max_workers,
             max_tasks_in_memory=self.options.max_tasks)
         self.started = False
 

--- a/flower/options.py
+++ b/flower/options.py
@@ -29,6 +29,8 @@ define("oauth2_secret", type=str, default=None,
        help="OAuth2 secret (requires --auth)")
 define("oauth2_redirect_uri", type=str, default=None,
        help="OAuth2 redirect uri (requires --auth)")
+define("max_workers", type=int, default=5000,
+       help="maximum number of workers to keep in memory")
 define("max_tasks", type=int, default=10000,
        help="maximum number of tasks to keep in memory")
 define("db", type=str, default='flower',


### PR DESCRIPTION
Add max_workers option. This is required when running celery workers in docker containers because they get new unique hostname on each deploy and flower is getting flooded with offline workers from stopped containers. Specifying --max-workers=10 solves this problem.