### PR TITLE
replaced map to list comprehension

### DIFF
--- a/flower/command.py
+++ b/flower/command.py
@@ -40,7 +40,7 @@ class FlowerCommand(Command):
             value = os.environ[env_var_name]
             option = options._options[name]
             if option.multiple:
-                value = map(option.type, value.split(','))
+                value = [option.type(i) for i in value.split(',')]
             else:
                 value = option.type(value)
             setattr(options, name, value)


### PR DESCRIPTION
In python 3 `map` returns generator and tornado raise exception while processing env variable like:
`FLOWER_BASIC_AUTH="admin:passw1,user:passw2"`

```
tornado.options.Error: Option 'basic_auth' is required to be a list of str
```