### PR TITLE
Added tasks table update via WebSockets

### DIFF
--- a/flower/api/events.py
+++ b/flower/api/events.py
@@ -20,7 +20,6 @@ class EventsApiHandler(BaseWebSocketHandler):
 EVENTS = ('task-sent', 'task-received', 'task-started', 'task-succeeded',
           'task-failed', 'task-revoked', 'task-retried', 'task-custom')
 
-
 def getClassName(eventname):
     return ''.join(map(lambda x: x[0].upper() + x[1:], eventname.split('-')))
 
@@ -32,6 +31,8 @@ for event in EVENTS:
     setattr(thismodule, classname,
             type(classname, (EventsApiHandler, ), {'listeners': []}))
 
+setattr(thismodule, 'TasksUpdate',
+            type('TasksUpdate', (EventsApiHandler, ), {'listeners': []}))
 
 __all__ = list(map(getClassName, EVENTS))
 __all__.append(getClassName)

--- a/flower/events.py
+++ b/flower/events.py
@@ -46,6 +46,9 @@ class EventsState(State):
         cls = getattr(api.events, classname, None)
         if cls:
             cls.send_message(event)
+        
+        if 'task' in event_type:
+            api.events.TasksUpdate.send_message(event)
 
         # Save the event
         super(EventsState, self).event(event)

--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -570,7 +570,7 @@ var flower = (function () {
                 var update = $.parseJSON(event.data);
                 on_dashboard_update(update);
             };
-        } else if ($.inArray($(location).attr('pathname'), ['/', '/tasks']) !== -1) {
+        } else if ($.inArray($(location).attr('pathname'), ['/tasks']) !== -1) {
             var host = $(location).attr('host'),
                 protocol = $(location).attr('protocol') === 'http:' ? 'ws://' : 'wss://',
                 ws = new WebSocket(protocol + host + "/api/task/events/update-tasks/");
@@ -782,7 +782,7 @@ var flower = (function () {
                 data: 'name',
                 visible: isColumnVisible('name'),
                 render: function (data, type, full, meta) {
-                    return '<a href="/task/' + data + '">' + data + '</a>';
+                    return data;
                 }
             }, {
                 targets: 1,

--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -397,6 +397,11 @@ var flower = (function () {
         $('a#btn-retried').text('Retried: ' + table.column(6).data().reduce(sum, 0));
     }
 
+    function on_tasks_update(update) {
+        var table = $('#tasks-table').DataTable();
+        table.draw('page');
+    }
+
     function on_cancel_task_filter(event) {
         event.preventDefault();
         event.stopPropagation();
@@ -564,6 +569,14 @@ var flower = (function () {
             ws.onmessage = function (event) {
                 var update = $.parseJSON(event.data);
                 on_dashboard_update(update);
+            };
+        } else if ($.inArray($(location).attr('pathname'), ['/', '/tasks']) !== -1) {
+            var host = $(location).attr('host'),
+                protocol = $(location).attr('protocol') === 'http:' ? 'ws://' : 'wss://',
+                ws = new WebSocket(protocol + host + "/api/task/events/update-tasks/");
+            ws.onmessage = function (event) {
+                var update = $.parseJSON(event.data);
+                on_tasks_update(update)
             };
         }
 

--- a/flower/urls.py
+++ b/flower/urls.py
@@ -68,6 +68,7 @@ handlers = [
     (r"/api/task/events/task-revoked/(.*)", events.TaskRevoked),
     (r"/api/task/events/task-retried/(.*)", events.TaskRetried),
     (r"/api/task/events/task-custom/(.*)", events.TaskCustom),
+    (r"/api/task/events/update-tasks/", events.TasksUpdate),
     # WebSocket Updates
     (r"/update-dashboard", DashboardUpdateHandler),
     # Monitors


### PR DESCRIPTION
Implement DataTable updates via Websocket push #543 

Method may be incomplete still, but works fine, I have not yet run the test suite.

Suggestion for improvement, to add a switcher button to turn on/off the auto-updating since application could be processing too many tasks, making impossible to read the table.
