### PR TITLE
Fix a bug in humanizing timestamps on the tasks page

### DIFF
--- a/flower/templates/tasks.html
+++ b/flower/templates/tasks.html
@@ -51,8 +51,8 @@
             {{ task.exception }}
         {% end %}
       </td>
-      <td>{{ humanize(task.started, type=time) }}</td>
-      <td>{{ humanize(task.received, type=time) }}</td>
+      <td>{{ humanize(task.started, type='time') }}</td>
+      <td>{{ humanize(task.received, type='time') }}</td>
       <td>
         {% if task.timestamp and task.started %}
             {{ '%.2f' % humanize(task.timestamp - task.started) }} sec


### PR DESCRIPTION
Previously, these were not humanized as timestamps with timezone info and were inconsistent with the timestamp displayed on the task/ page