### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Or receive task completion events in real-time:
 
 For more info checkout `API Reference`_ and `examples`_.
 
-.. _API Reference: http://flower.readthedocs.org/en/latest/api.html
+.. _API Reference: https://flower.readthedocs.io/en/latest/api.html
 .. _examples: http://nbviewer.ipython.org/urls/raw.github.com/mher/flower/master/docs/api.ipynb
 
 Installation
@@ -110,7 +110,7 @@ Documentation
 
 Documentation is available at `Read the Docs`_ and `IPython Notebook Viewer`_
 
-.. _Read the Docs: http://flower.readthedocs.org
+.. _Read the Docs: https://flower.readthedocs.io
 .. _IPython Notebook Viewer: http://nbviewer.ipython.org/urls/raw.github.com/mher/flower/master/docs/api.ipynb
 
 License

--- a/flower/templates/navbar.html
+++ b/flower/templates/navbar.html
@@ -16,7 +16,7 @@
         </ul>
         <ul class="nav pull-right">
           <li><a href="{{ reverse_url('logout') }}">Logout</a></li>
-          <li><a href="http://flower.readthedocs.org" target="_blank">Docs</a></li>
+          <li><a href="https://flower.readthedocs.io" target="_blank">Docs</a></li>
           <li><a href="https://github.com/mher/flower" target="_blank">Code</a></li>
         </ul>
       </div>


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.