### PR TITLE
Support environment variables in tornado 4.2.0 and >=4.3

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -67,3 +67,4 @@ Misha Behersky
 Sebastian Kalinowski
 Jingyu Zhou
 Maxim Krivodaev
+Alli Witheford

--- a/flower/command.py
+++ b/flower/command.py
@@ -64,7 +64,10 @@ class FlowerCommand(Command):
         for env_var_name in env_options:
             name = env_var_name.replace(self.ENV_VAR_PREFIX, '', 1).lower()
             value = os.environ[env_var_name]
-            option = options._options[name]
+            try:
+                option = options._options[name]
+            except:
+                option = options._options[name.replace('_', '-')]
             if option.multiple:
                 value = [option.type(i) for i in value.split(',')]
             else:

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 celery>=3.1.0
-tornado==4.2.0
+tornado>=4.2.0
 babel>=1.0
 pytz


### PR DESCRIPTION
Tornado normalizes all option names to be dashes `-` instead of underscores `_` since 4.3.
(https://github.com/tornadoweb/tornado/commit/463669e9e085d6048e233db5a47a9e8895ff554b)

As flower handles environment variables as well, special handling is needed to support
environment variables on 4.2 and 4.3 and above.

patch for #586