### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,12 @@ language: python
 os:
   - linux
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
+  - "3.5"
   - "pypy"
 install:
-  - travis_retry pip install -r requirements/dev.txt --use-mirrors
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict futures; fi
+  - travis_retry pip install -r requirements/dev.txt
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install futures; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install futures; fi
 script:


### PR DESCRIPTION
drop target 2.6, not supported by celery (or dependencies including billiard)

use same targets as celery 4.0 supports, except pypy3 which doesn't work

remove "--use-mirrors", travis reports no such option