### PR TITLE
API : allow search and sort (especially by eta) and fix a unicode search in the string representation of a dict

### DIFF
--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -21,7 +21,6 @@ from ..views import BaseHandler
 from ..utils.broker import Broker
 from ..api.control import ControlHandler
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -477,6 +476,8 @@ List tasks
         worker = self.get_argument('workername', None)
         type = self.get_argument('taskname', None)
         state = self.get_argument('state', None)
+        search = self.get_argument('search', None)
+        sort = self.get_argument('sort', None)
 
         limit = limit and int(limit)
         worker = worker if worker != 'All' else None
@@ -485,7 +486,7 @@ List tasks
 
         result = []
         for task_id, task in tasks.iter_tasks(
-                app.events, limit=limit, type=type,
+                app.events, limit=limit, type=type, sort_by=sort, search=search,
                 worker=worker, state=state):
             task = tasks.as_dict(task)
             task.pop('worker', None)
@@ -598,6 +599,6 @@ Get a task info
             if name not in ['uuid', 'worker']:
                 response[name] = getattr(task, name, None)
         response['task-id'] = task.uuid
-        if task.worker is not None:
-            response['worker'] = task.worker.hostname
+	if task.worker is not None:
+        	response['worker'] = task.worker.hostname
         self.write(response)

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -599,6 +599,6 @@ Get a task info
             if name not in ['uuid', 'worker']:
                 response[name] = getattr(task, name, None)
         response['task-id'] = task.uuid
-	if task.worker is not None:
-        	response['worker'] = task.worker.hostname
+        if task.worker is not None:
+                response['worker'] = task.worker.hostname
         self.write(response)

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -594,11 +594,8 @@ Get a task info
         task = tasks.get_task_by_id(self.application.events, taskid)
         if not task:
             raise HTTPError(404, "Unknown task '%s'" % taskid)
-        response = {}
-        for name in task._fields:
-            if name not in ['uuid', 'worker']:
-                response[name] = getattr(task, name, None)
-        response['task-id'] = task.uuid
-        if task.worker is not None:
-                response['worker'] = task.worker.hostname
+        # avoid to recode the serialization already done on the celery side
+        response = task.as_dict()
+        # special case for the Worker object
+        response['worker'] = task.worker.hostname
         self.write(response)

--- a/flower/utils/search.py
+++ b/flower/utils/search.py
@@ -57,10 +57,15 @@ def stringified_dict_contains_value(key, value, str_dict):
     key/value pair. This works faster, then creating actual dict
     from string since this operation is called for each task in case
     of kwargs search."""
+    if str_dict is None:
+       return False
     value = str(value)
     try:
         # + 3 for key right quote, one for colon and one for space
         key_index = str_dict.index(key) + len(key) + 3
+        if str_dict[key_index:].find("u'")==0:
+            # String value, should add 2 characters
+            key_index+=2
     except ValueError:
         return False
     try:

--- a/flower/utils/tasks.py
+++ b/flower/utils/tasks.py
@@ -46,9 +46,7 @@ def iter_tasks(events, limit=None, type=None, worker=None, state=None,
         if i == limit:
             break
 
-
-sort_keys = {'name': str, 'state': str, 'received': float, 'started': float}
-
+sort_keys = {'name': str, 'state': str, 'received': float, 'started': float, 'eta': str}
 
 def sort_tasks(tasks, sort_by):
     assert sort_by.lstrip('-') in sort_keys


### PR DESCRIPTION
Hello Mher,

For our project we had to patch flower 0.8.4 (and then 0.9.0) because searching and sorting issues.
- search filter was not taken into account at all
- fix the string string and optimization
- allow sorting by eta

Would you please mind having a look please ?
Thierry