### PR TITLE
Smaller and simpler Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,20 @@
-FROM ubuntu:12.04
+FROM python:alpine
 
-RUN apt-get update
-RUN apt-get install -y wget ca-certificates
+# Get latest root certificates
+RUN apk add --update ca-certificates && update-ca-certificates
 
-# Install pip
-RUN cd /tmp; wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py;\
- python get-pip.py; rm get-pip.py;
-
-# Install pip via package-manager 
-RUN apt-get install -y python-pip
-
-# add flower
+# Install the required packages
 RUN pip install redis flower
 
+# PYTHONUNBUFFERED: Force stdin, stdout and stderr to be totally unbuffered. (equivalent to `python -u`)
+# PYTHONHASHSEED: Enable hash randomization (equivalent to `python -R`)
+# PYTHONDONTWRITEBYTECODE: Do not write byte files to disk, since we maintain it as readonly. (equivalent to `python -B`)
+ENV PYTHONUNBUFFERED=1 PYTHONHASHSEED=random PYTHONDONTWRITEBYTECODE=1
+
+# Default port
+EXPOSE 5555
+
+# Run as a non-root user by default, run as user with least privileges.
+USER nobody
+
+ENTRYPOINT ["flower"]


### PR DESCRIPTION
- Smaller size (around 150MB).
- Runs on latest Python (3.5.x)
- Runs as non-root user by default.
