### PR TITLE
Wrap task args and kwargs inside a container to prevent tasks table…

### DIFF
--- a/flower/static/css/flower.css
+++ b/flower/static/css/flower.css
@@ -229,3 +229,12 @@
   width: 100%;
   display: inline-block;
 }
+
+#tasks-table .code-overflow {
+  overflow: auto;
+  max-height: 200px;
+}
+
+#tasks-table .code-overflow code {
+  display: block;
+}

--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -796,11 +796,17 @@ var flower = (function () {
             }, {
                 targets: 3,
                 data: 'args',
-                visible: isColumnVisible('args')
+                visible: isColumnVisible('args'),
+                render: function ( data, type, row ) {
+                    return '<div class="code-overflow"><code>' + data + '</code></div>';
+                }
             }, {
                 targets: 4,
                 data: 'kwargs',
-                visible: isColumnVisible('kwargs')
+                visible: isColumnVisible('kwargs'),
+                render: function ( data, type, row ) {
+                    return '<div class="code-overflow"><code>' + data + '</code></div>';
+                }
             }, {
                 targets: 5,
                 data: 'result',


### PR DESCRIPTION
… from blowing up.

Issue: given that task paramenters contain pickled data the table becomes mangled (pickled data contains code similar to closing/opening html tags). Additionally, if the pickled argument is long then the task table becomes unreadable and unmanageable with rows reaching heights thousands pixels high.

See result:
![lol](https://cloud.githubusercontent.com/assets/10219607/20749656/793ce108-b6f3-11e6-960c-8f184705eb24.png)
