### PR TITLE
Fix celery version comparsion

### DIFF
--- a/flower/events.py
+++ b/flower/events.py
@@ -67,7 +67,7 @@ class Events(threading.Thread):
         self.enable_events = enable_events
         self.state = None
 
-        if self.persistent and celery.__version__ < '3.0.15':
+        if self.persistent and tuple([int(s) for s in celery.__version__.split('.')]) < (3, 0, 15):
             logger.warning('Persistent mode is available with '
                            'Celery 3.0.15 and later')
             self.persistent = False


### PR DESCRIPTION
Fix celery version comparsion.

```
In [1]: '3.0.2' < '3.0.15'
Out[1]: False
```