### PR TITLE
Add tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Documentation/
 .vagrant
 env
 venv
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,8 @@ python:
   - "3.6"
   - "pypy"
 install:
-  - travis_retry pip install -q Celery==$CELERY_VERSION
-  - travis_retry pip install -q -r requirements/dev.txt
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install futures; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install futures; fi
-env:
-  - TEST_SUITE=unit CELERY_VERSION=4.0.2
-  - TEST_SUITE=unit CELERY_VERSION=3.1.24
+  - pip install tox-travis
 before_script:
   - pip freeze
 script:
-  - ./tests/run-unit-tests.sh
+  - tox

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ classes = """
     Topic :: System :: Distributed Computing
     Programming Language :: Python
     Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.6
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.3

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ classes = """
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py33,py34,py35,py36}-{celery3,celery4}
+envlist = {py27,py33,py34,py35,py36,pypy,pyp3}-{celery3,celery4}
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27,py33,py34,py35
+skip_missing_interpreters = True
+
+[testenv]
+deps =
+    mock
+    pytest
+commands =
+    py.test tests/

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,16 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = {py27,py33,py34,py35,py36}-{celery3,celery4}
 skip_missing_interpreters = True
 
 [testenv]
 deps =
     mock
     pytest
+setenv =
+    celery3: CELERY_VERSION=3.1.24
+    celery4: CELERY_VERSION=4.0.2
 commands =
+    pip install -q Celery=={env:CELERY_VERSION}
     py.test tests/
+passenv =
+    CELERY_VERSION


### PR DESCRIPTION
Test on multiple versions of python.

Drop 2.6 support marker from setup.py - 2.6 doesn't work due to
celery/billiard dropping support