### PR TITLE
Fixes #618: invalid URL used for datatable query

### DIFF
--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -32,7 +32,11 @@ var flower = (function () {
     function url_prefix() {
         var url_prefix = $('#url_prefix').val();
         if (url_prefix) {
-            return '/' + url_prefix;
+            if (url_prefix.startsWith('/')) {
+                return url_prefix;
+            } else {
+                return '/' + url_prefix;
+            }
         }
         return '';
     }


### PR DESCRIPTION
Fixes no graph in the monitor page too
Caused by url_prefix with a leading slash