### PR TITLE
Fixes in config documents

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -71,3 +71,4 @@ Alli Witheford
 Alexander Zaitsev
 Anton Prokhorov
 Sharang Phadke
+Moinuddin Quadri

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -85,18 +85,18 @@ of `username:passworrd`. See :ref:`basic-auth` for more info.
 broker_api
 ~~~~~~~~~~
 
-Flower uses `RabbitMQ Managment Plugin`_ to get info about queues.
+Flower uses `RabbitMQ Management Plugin`_ to get info about queues.
 `broker_api` is a URL of RabbitMQ HTTP API including user credentials. ::
 
     $ flower -A proj --broker_api=http://username:password@rabbitmq-server-name:15672/api/
 
-.. Note:: By default the managment plugin is not enabled. To enable it run::
+.. Note:: By default the management plugin is not enabled. To enable it run::
 
     $ rabbitmq-plugins enable rabbitmq_management
 
 .. Note:: The port number for RabbitMQ versions prior to 3.0 is 55672.
 
-.. _`RabbitMQ Managment Plugin`: https://www.rabbitmq.com/management.html
+.. _`RabbitMQ Management Plugin`: https://www.rabbitmq.com/management.html
 
 .. _ca_certs:
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -105,7 +105,7 @@ ca_certs
 
 A path to `ca_certs` file. The `ca_certs` file contains a set of concatenated “certification authority”
 certificates, which are used to validate certificates passed from the other end of the connection.
-For more info see :ref:`Python SSL`_
+For more info see `Python SSL`_
 
 .. _`Python SSL`: https://docs.python.org/3.4/library/ssl.html
 


### PR DESCRIPTION
1. Fixed typo in config document: Managment -> Management
2. Currently the link for Python SSL is broken. It is declared as an explicit link but defined as an external link. Since it is an external link, fixing its declaration.

