### PR TITLE
add /api/workers/clear-cache

### DIFF
--- a/flower/api/control.py
+++ b/flower/api/control.py
@@ -23,6 +23,12 @@ class ControlHandler(BaseHandler):
         yield self.update_workers(workername=workername,
                                   app=self.application)
 
+    @gen.coroutine
+    def clear_workers_cache(self):
+        logger.debug("Clearing worker cache...")
+        self.worker_cache = {}
+        yield self.update_workers(app=self.application)
+
     @classmethod
     @gen.coroutine
     def update_workers(cls, app, workername=None):

--- a/flower/api/workers.py
+++ b/flower/api/workers.py
@@ -185,3 +185,48 @@ List workers
             self.write({workername: self.worker_cache[workername]})
         else:
             self.write(self.worker_cache)
+
+
+class ClearWorkersCache(ControlHandler):
+    @web.authenticated
+    @gen.coroutine
+    def post(self):
+        """
+Clear workers in cache
+
+**Example request**:
+
+.. sourcecode:: http
+
+  POST /api/workers/clear-cache HTTP/1.1
+  Content-Length: 0
+  Host: localhost:5555
+
+**Example response**:
+
+.. sourcecode:: http
+
+  HTTP/1.1 200 OK
+  Content-Length: 29
+  Content-Type: application/json; charset=UTF-8
+
+  {
+      "message": "Cleared workers in cache"
+  }
+
+:reqheader Authorization: optional OAuth token to authenticate
+:statuscode 200: no error
+:statuscode 401: unauthorized request
+        """
+
+
+        logger.info("Clearing worker cache")
+
+        try:
+            yield self.clear_workers_cache()
+        except Exception as e:
+            msg = "Failed to clear cache: %s" % e
+            logger.error(msg)
+            raise web.HTTPError(503, msg)
+
+        self.write(dict(message="Cleared workers in cache"))

--- a/flower/static/swagger.json
+++ b/flower/static/swagger.json
@@ -342,7 +342,7 @@
             "description": "result"
           }
         },
-        "description": "List workers",
+        "description": "Clear flower workers cache",
         "parameters": [ ]
       }
     },

--- a/flower/static/swagger.json
+++ b/flower/static/swagger.json
@@ -1,0 +1,534 @@
+{
+  "tags": [
+    
+  ],
+  "paths": {
+    "\/api\/tasks": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Result"
+          }
+        },
+        "description": "List tasks",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "the maximum number of tasks",
+            "required": false,
+            "format": "int32",
+            "type": "integer"
+          },
+          {
+            "name": "workername",
+            "in": "query",
+            "description": "filter task by workername",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "taskname",
+            "in": "query",
+            "description": "filter task by taskname",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "description": "filter task by state",
+            "required": false,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "\/api\/task\/types": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "List (seen) task types"
+      }
+    },
+    "\/api\/queues\/length": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Get queue lengths"
+      }
+    },
+    "\/api\/task\/info\/{taskid}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Get task info",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/taskid"
+          }
+        ]
+      }
+    },
+    "\/api\/task\/apply\/{taskname}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Execute a task by name and wait results",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/taskname"
+          },
+          {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "kwargs": {
+                  "type": "object"
+                },
+                "args": {
+                  "type": "array"
+                }
+              }
+            },
+            "name": "args",
+            "description": "the dictionary of args and kwargs",
+            "in": "body"
+          }
+        ]
+      }
+    },
+    "\/api\/task\/async-apply\/{taskname}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Execute a task",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/taskname"
+          },
+          {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "kwargs": {
+                  "type": "object"
+                },
+                "args": {
+                  "type": "array"
+                },
+                "options": {
+                  "type": "object"
+                }
+              }
+            },
+            "name": "args",
+            "description": "the dictionary of args, kwargs, and apply-async options",
+            "in": "body"
+          }
+        ]
+      }
+    },
+    "\/api\/task\/send-task\/{taskname}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Execute a task by name (Doesn't require a task source)",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/taskname"
+          },
+          {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "kwargs": {
+                  "type": "object"
+                },
+                "args": {
+                  "type": "array"
+                }
+              }
+            },
+            "name": "args",
+            "description": "the dictionary of args, and kwargs",
+            "in": "body"
+          }
+        ]
+      }
+    },
+    "\/api\/task\/result\/{taskid}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Execute a task by name and wait results",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/taskid"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "how long to wait, in seconds, before the operation times out",
+            "required": false,
+            "format": "int32",
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    "\/api\/task\/abort\/{taskid}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Abort a running task",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/taskid"
+          }
+        ]
+      }
+    },
+    "\/api\/task\/timeout\/{taskname}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Change soft and hard time limits for a task",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/taskname"
+          },
+          {
+            "name": "workername",
+            "in": "query",
+            "description": "the name of a worker",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "soft",
+            "in": "query",
+            "description": "the soft timeout limit",
+            "required": false,
+            "format": "int32",
+            "type": "integer"
+          },
+          {
+            "name": "hard",
+            "in": "query",
+            "description": "the hard timeout limit",
+            "required": false,
+            "format": "int32",
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    "\/api\/task\/rate-limit\/{taskname}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Change rate limit for a task",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/taskname"
+          },
+          {
+            "name": "workername",
+            "in": "query",
+            "description": "the name of a worker",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "rateLimit",
+            "in": "query",
+            "description": "the rate limit to apply",
+            "required": true,
+            "format": "int32",
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    "\/api\/task\/revoke\/{taskid}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Revoke a task",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/taskid"
+          },
+          {
+            "name": "terminate",
+            "in": "query",
+            "description": "terminate the task if it is running",
+            "required": false,
+            "type": "boolean"
+          }
+        ]
+      }
+    },
+    "\/api\/workers": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "List workers",
+        "parameters": [
+          {
+            "name": "refresh",
+            "in": "query",
+            "description": "run inspect to get updated list of workers",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "workername",
+            "in": "query",
+            "description": "get info for workername",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "description": "only get worker status info",
+            "in": "query",
+            "type": "boolean"
+          }
+        ]
+      }
+    },
+        "\/api\/workers\/clear-cache": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "List workers",
+        "parameters": [ ]
+      }
+    },
+    "\/api\/worker\/shutdown\/{workername}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Shut down a worker",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/workername"
+          }
+        ]
+      }
+    },
+    "\/api\/worker\/pool\/restart\/{workername}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Restart a worker's pool",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/workername"
+          }
+        ]
+      }
+    },
+    "\/api\/worker\/pool\/grow\/{workername}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Grow a worker's pool",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/workername"
+          },
+          {
+            "name": "n",
+            "in": "query",
+            "description": "number of pool processes to grow, default is 1",
+            "required": false,
+            "format": "int32",
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    "\/api\/worker\/pool\/shrink\/{workername}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Shrink a worker's pool",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/workername"
+          },
+          {
+            "name": "n",
+            "in": "query",
+            "description": "number of pool processes to shrink, default is 1",
+            "required": false,
+            "format": "int32",
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    "\/api\/worker\/pool\/autoscale\/{workername}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Autoscale a worker pool",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/workername"
+          },
+          {
+            "name": "min",
+            "in": "query",
+            "description": "minimum number of pool processes",
+            "required": false,
+            "format": "int32",
+            "type": "integer"
+          },
+          {
+            "name": "max",
+            "in": "query",
+            "description": "maximum number of pool processes",
+            "required": false,
+            "format": "int32",
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    "\/api\/worker\/queue\/add-consumer\/{workername}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Start consuming from a queue",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/workername"
+          },
+          {
+            "name": "queue",
+            "in": "query",
+            "description": "the name of a queue",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "\/api\/worker\/queue\/cancel-consumer\/{workername}": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "result"
+          }
+        },
+        "description": "Stop consuming from a queue",
+        "parameters": [
+          {
+            "$ref": "#\/parameters\/workername"
+          },
+          {
+            "name": "queue",
+            "in": "query",
+            "description": "the name of a queue",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {
+    "taskid": {
+      "type": "string",
+      "in": "path",
+      "description": "The task id",
+      "required": true,
+      "name": "taskid"
+    },
+    "workername": {
+      "type": "string",
+      "in": "path",
+      "description": "The worker name",
+      "required": true,
+      "name": "workername"
+    },
+    "taskname": {
+      "type": "string",
+      "in": "path",
+      "description": "The task name",
+      "required": true,
+      "name": "taskname"
+    }
+  },
+  "info": {
+    "description": "The flower API spec",
+    "version": "1.0.0-dev",
+    "title": "Flower"
+  },
+  "definitions": {
+    
+  },
+  "swagger": "2.0"
+}
+

--- a/flower/urls.py
+++ b/flower/urls.py
@@ -38,6 +38,7 @@ handlers = [
     url(r"/broker", BrokerView, name='broker'),
     # Worker API
     (r"/api/workers", workers.ListWorkers),
+    (r"/api/workers/clear-cache", workers.ClearWorkersCache),
     (r"/api/worker/shutdown/(.+)", control.WorkerShutDown),
     (r"/api/worker/pool/restart/(.+)", control.WorkerPoolRestart),
     (r"/api/worker/pool/grow/(.+)", control.WorkerPoolGrow),


### PR DESCRIPTION
This feature gives us a way to flush stale worker info out of the flower worker cache dictionary without restarting flower.