### PR TITLE
Fix "not JSON serializable" `TypeError` for /api/task/info

### DIFF
--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -600,11 +600,9 @@ Get a task info
         task = tasks.get_task_by_id(self.application.events, taskid)
         if not task:
             raise HTTPError(404, "Unknown task '%s'" % taskid)
-        response = {}
-        for name in task._fields:
-            if name not in ['uuid', 'worker']:
-                response[name] = getattr(task, name, None)
-        response['task-id'] = task.uuid
+
+        response = task.as_dict()
         if task.worker is not None:
             response['worker'] = task.worker.hostname
+
         self.write(response)

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from mock import Mock, patch
 from datetime import datetime, timedelta
 
 from celery.result import AsyncResult
@@ -82,3 +82,18 @@ class AsyncApplyTests(AsyncHTTPTestCase):
         self.assertEqual(200, r.code)
         task.apply_async.assert_called_once_with(
             args=[], kwargs={}, expires=tomorrow)
+
+
+class MockTasks:
+
+    @staticmethod
+    def get_task_by_id(events, task_id):
+        from celery.events.state import Task
+        return Task()
+
+
+class TaskTests(AsyncHTTPTestCase):
+
+    @patch('flower.api.tasks.tasks', new=MockTasks)
+    def test_task_info(self):
+        self.get('/api/task/info/123')


### PR DESCRIPTION
Related to #617 