### PR TITLE
Enhancement: Added feature to manually retry failed tasks

### DIFF
--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -325,6 +325,30 @@ var flower = (function () {
         });
     }
 
+    function on_task_requeue(event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        var taskname = $('#taskname').text();
+        var taskargs = $('#taskargs').text();
+        var taskkwargs = $('#taskkwargs').text();
+
+        $.ajax({
+            type: 'POST',
+            url: url_prefix() + '/api/task/async-apply/' + taskname,
+            dataType: 'json',
+            data: '{"args":' + taskargs + ', "kwargs":' + taskkwargs + '}',
+            success: function (data) {
+                var message = 'Requeued UUID: ' + data['task-id']
+                show_success_alert(message);
+            },
+            error: function (data) {
+                show_error_alert('Cannot enqueue task. In addition to broker, is Flower configured with correct ' +
+                    'Celery app/task config (e.g. --app or CELERY_APP)?');
+            }
+        });
+    }
+
     function on_task_terminate(event) {
         event.preventDefault();
         event.stopPropagation();
@@ -859,6 +883,7 @@ var flower = (function () {
         on_task_timeout: on_task_timeout,
         on_task_rate_limit: on_task_rate_limit,
         on_cancel_task_filter: on_cancel_task_filter,
+        on_task_requeue: on_task_requeue,
         on_task_revoke: on_task_revoke,
         on_task_terminate: on_task_terminate,
     };

--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -16,6 +16,8 @@
                 <button style="float: right" class="btn btn-danger" onclick="flower.on_task_terminate(event)">Terminate</button>
             {% elif task.state == "RECEIVED" or task.state == "RETRY" %}
                 <button  style="float: right" class="btn btn-danger" onclick="flower.on_task_revoke(event)">Revoke</button>
+            {% elif task.state == "FAILURE" %}
+                <button  style="float: right" class="btn btn-success" onclick="flower.on_task_requeue(event)">Requeue</button>
             {% end %}
           </h2>
         </div>
@@ -26,7 +28,7 @@
               <tbody>
               <tr>
                 <td>Name</td>
-                <td>{{ getattr(task, 'name', None) }}</td>
+                <td id="taskname">{{ getattr(task, 'name', None) }}</td>
               </tr>
               <tr>
                 <td>UUID</td>
@@ -46,11 +48,11 @@
               </tr>
               <tr>
                 <td>args</td>
-                <td>{{ task.args }}</td>
+                <td id="taskargs">{{ task.args }}</td>
               </tr>
               <tr>
                 <td>kwargs</td>
-                <td>{{ task.kwargs }}</td>
+                <td id="taskkwargs">{{ task.kwargs }}</td>
               </tr>
               <tr>
                 <td>Result</td>


### PR DESCRIPTION
This PR is based on @jiffyjeff's work #158 with follow-up to be ready to be merged.

Enhancement: Added feature to manually retry failed tasks. Added "Requeue" button to task detail view; requeues the task with original args and kwargs using the Flower async-apply API. Supports an existing feature request (#17).