### PR TITLE
Introduce TTLCache for the counter in the EventsState-class.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -111,6 +111,16 @@ For more info see `Python SSL`_
 
 .. _certfile:
 
+
+cache_ttl
+~~~~~~~~
+
+This option can be used to remove workers that went offline from the dashboard.
+To precise, this parameter specifies the time-to-live in seconds for elements that have been added to the cache
+which is used to list the workers on the dashboard.
+(by default, `cache_ttl=1E10` in seconds)
+
+
 certfile
 ~~~~~~~~
 

--- a/flower/app.py
+++ b/flower/app.py
@@ -39,7 +39,8 @@ class Flower(tornado.web.Application):
             enable_events=self.options.enable_events,
             io_loop=self.io_loop,
             max_workers_in_memory=self.options.max_workers,
-            max_tasks_in_memory=self.options.max_tasks)
+            max_tasks_in_memory=self.options.max_tasks,
+            cache_ttl=self.options.cache_ttl)
         self.started = False
 
     def start(self):

--- a/flower/events.py
+++ b/flower/events.py
@@ -10,6 +10,7 @@ import collections
 from functools import partial
 
 import celery
+from cachetools import TTLCache
 
 from tornado.ioloop import PeriodicCallback
 from tornado.ioloop import IOLoop
@@ -27,13 +28,12 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-
 class EventsState(State):
     # EventsState object is created and accessed only from ioloop thread
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, cache_ttl=1E10, *args, **kwargs):
         super(EventsState, self).__init__(*args, **kwargs)
-        self.counter = collections.defaultdict(Counter)
+        self.counter = TTLCache(maxsize=kwargs.get('max_workers_in_memory', 5000), ttl=cache_ttl, missing=lambda x: Counter())
 
     def event(self, event):
         worker_name = event['hostname']

--- a/flower/options.py
+++ b/flower/options.py
@@ -65,6 +65,8 @@ define("tasks_columns", type=str,
 define("auth_provider", default='flower.views.auth.GoogleAuth2LoginHandler',
        help="auth handler class")
 define("url_prefix", type=str, help="base url prefix")
+define("cache_ttl", type=int, default=1E10,
+       help="Time-to-live in seconds for elements of the cache for the workers listed on the dashboard.")
 
 # deprecated options
 define("inspect", default=False, help="inspect workers", type=bool)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,3 +2,4 @@ celery>=3.1.0
 tornado>=4.2.0
 babel>=1.0
 pytz
+cachetools>=2.0.0


### PR DESCRIPTION
This should invalidate worker that went offline automatically so that they are not show on the dashboard anymore.
Default value of the related parameter `cache_ttl` is chosen in a way that the behaviour of Flower should stay untouched.