### PR TITLE
add uuid_redirect url

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -308,3 +308,14 @@ Sets authentication provider
   - GitHub `flower.views.auth.GithubLoginHandler`
 
 See `Authentication` for usage examples
+
+.. _uuid_redirect:
+
+uuid_redirect
+~~~~~~~~~~~
+
+Add a redirection URL to UUID in the task page. For example, you can connect to logtrail using:
+
+.. code-block::
+
+    --uuid_redirect "http://subdomain.mycompany.com/kibana/app/logtrail#/?q=uuid%3A%20%22{{ uuid }}%22&t=Now"

--- a/flower/options.py
+++ b/flower/options.py
@@ -65,6 +65,7 @@ define("tasks_columns", type=str,
 define("auth_provider", default='flower.views.auth.GoogleAuth2LoginHandler',
        help="auth handler class")
 define("url_prefix", type=str, help="base url prefix")
+define("uuid_redirect", type=str, help="url to redirect uuid links to")
 
 # deprecated options
 define("inspect", default=False, help="inspect workers", type=bool)

--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -30,7 +30,13 @@
               </tr>
               <tr>
                 <td>UUID</td>
-                <td>{{ task.uuid }}</td>
+                <td>
+                  {%- if uuid_redirect -%}
+                    <a href="{{ uuid_redirect }}" target="_blank">{{ task.uuid }}</a>
+                  {%- else -%}
+                    {{ task.uuid }}
+                  {%- end -%}
+                </td>
               </tr>
               <tr>
                 <td>State</td>

--- a/flower/views/tasks.py
+++ b/flower/views/tasks.py
@@ -21,11 +21,14 @@ class TaskView(BaseHandler):
     @web.authenticated
     def get(self, task_id):
         task = get_task_by_id(self.application.events, task_id)
+        uuid_redirect = self.application.options.uuid_redirect
+        if uuid_redirect:
+            uuid_redirect.replace('{{ uuid }}',task.uuid)
 
         if task is None:
             raise web.HTTPError(404, "Unknown task '%s'" % task_id)
 
-        self.render("task.html", task=task)
+        self.render("task.html", task=task, uuid_redirect=uuid_redirect)
 
 
 @total_ordering


### PR DESCRIPTION
This patch adds an option `--uuid_redirect` to render a link on the uuid page to an external tool that can use this uuid to display more information related to the task.

I use it to connect directly to logtrail plugin on kibana.

Signed-off-by: Gaetan Semet <gaetan@xeberon.net>