### PR TITLE
add option 'unix_socket_chmod'

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -290,6 +290,13 @@ unix_socket
 
 Run flower using UNIX socket file
 
+.. _unix_socket_chmod:
+
+unix_socket_chmod
+~~~~~~~~~~~
+
+UNIX socket file access permissions
+
 .. _cookie_secret:
 
 cookie_secret

--- a/flower/app.py
+++ b/flower/app.py
@@ -53,7 +53,8 @@ class Flower(tornado.web.Application):
         else:
             from tornado.netutil import bind_unix_socket
             server = HTTPServer(self)
-            socket = bind_unix_socket(self.options.unix_socket)
+            mode = int(self.options.unix_socket_chmod, 8)
+            socket = bind_unix_socket(self.options.unix_socket, mode=mode)
             server.add_socket(socket)
 
         self.io_loop.add_future(

--- a/flower/options.py
+++ b/flower/options.py
@@ -15,6 +15,8 @@ define("address", default='',
        help="run on the given address", type=str)
 define("unix_socket", default='',
        help="path to unix socket to bind", type=str)
+define("unix_socket_chmod", default='600',
+       help="unix socket access permissions", type=str)
 define("debug", default=False,
        help="run in debug mode", type=bool)
 define("inspect_timeout", default=1000, type=float,


### PR DESCRIPTION
An option to set socket permissions to override default 600.
Without such an option user has to manually chmod socket on every flower restart.
Should fix #725 