### PR TITLE
Add GitHub team IDs and Org names authorization

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -74,3 +74,4 @@ Sharang Phadke
 Moinuddin Quadri
 John Arnold
 Scott Kruger
+Fabio Todaro

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -64,11 +64,19 @@ GitHub OAuth should be activated using `--auth_provider` option.
 The client id, secret and redirect uri should be provided using
 `--oauth2_key`, `--oauth2_secret` and `--oauth2_redirect_uri` options or using
 `FLOWER_OAUTH2_KEY`, `FLOWER_OAUTH2_SECRET` and `FLOWER_OAUTH2_REDIRECT_URI`
-environment variables.: ::
+environment variables. ::
 
     $ export FLOWER_OAUTH2_KEY=7956724aafbf5e1a93ac
     $ export FLOWER_OAUTH2_SECRET=f9155f764b7e466c445931a6e3cc7a42c4ce47be
     $ export FLOWER_OAUTH2_REDIRECT_URI=http://localhost:5555/login
-    $ celery flower --auth_provider=flower.views.auth.GithubLoginHandler --auth=.*@example\.com
+
+The `auth` config must be a JSON containing at least one of 3 keys:
+    - emails: A regexp of allowed emails
+    - teams: A GitHub team id or an array of team ids
+    - orgs: A GitHub org name or an array of org names
+::
+
+    $ celery flower --auth_provider=flower.views.auth.GithubLoginHandler --auth='{"emails":".*@example\\.com", "teams":[1234,5678], "orgs":["MyOrg","MySecondOrg"]}'
+    $ celery flower --auth_provider=flower.views.auth.GithubLoginHandler --auth='{"teams":1234}'
 
 .. _GitHub OAuth API: https://developer.github.com/v3/oauth/

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -62,8 +62,16 @@ Run the http server on a given address
 auth
 ~~~~
 
-Enables Google OpenID authentication. `auth` is a regexp of emails
-to grant access. For more info see :ref:`google-openid`
+Enables Google OpenID or GitHub authentication.
+For Google `auth` is a regexp of emails allowed to access. ::
+
+    $ flower --auth_provider=flower.views.auth.GoogleAuth2LoginHandler --auth=".*@gmail.com"
+
+For GitHub `auth` is a JSON specifying email, teams or orgs allowed to access. ::
+
+    $ flower --auth_provider=flower.views.auth.GithubLoginHandler --auth='{"emails":".*@gmail\\.com", "teams":[1234,5678], "orgs":["MyOrg","MySecondOrg"]}'
+
+For more info see :ref:`authentication`
 
 .. _auto_refresh:
 
@@ -307,4 +315,4 @@ Sets authentication provider
   - Google `flower.views.auth.GoogleAuth2LoginHandler`
   - GitHub `flower.views.auth.GithubLoginHandler`
 
-See `Authentication` for usage examples
+See :ref:`authentication` for usage examples

--- a/flower/options.py
+++ b/flower/options.py
@@ -20,7 +20,7 @@ define("debug", default=False,
 define("inspect_timeout", default=1000, type=float,
        help="inspect timeout (in milliseconds)")
 define("auth", default='', type=str,
-       help="regexp of emails to grant access")
+       help="Google auth: regexp string of emails to grant access, GitHub auth: JSON config")
 define("basic_auth", type=str, default=None, multiple=True,
        help="enable http basic authentication")
 define("oauth2_key", type=str, default=None,

--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -70,8 +70,7 @@ class BaseHandler(tornado.web.RequestHandler):
         if user:
             if not isinstance(user, str):
                 user = user.decode()
-            if re.search(self.application.options.auth, user):
-                return user
+            return user
         return None
 
     def get_argument(self, name, default=[], strip=True, type=None):


### PR DESCRIPTION
Implements #726 

Using GitHub `auth_provider` you must pass a JSON string to `auth`

Examples:
```
--auth='{"emails":".*@example\\.com", "teams":[1234,5678], "orgs":["MyOrg","MySecondOrg"]}'
--auth='{"teams":1234}'
--auth='{"emails":".*@mycompany\\.com", "orgs":"MyOrg"}'
```