### PR TITLE
Add 'signal' query parameter to endpoint /api/task/revoke

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -74,3 +74,4 @@ Sharang Phadke
 Moinuddin Quadri
 John Arnold
 Scott Kruger
+David Schneider

--- a/flower/api/control.py
+++ b/flower/api/control.py
@@ -461,13 +461,15 @@ Revoke a task
   }
 
 :query terminate: terminate the task if it is running
+:query signal: name of signal to send to process if terminate (default: 'SIGTERM')
 :reqheader Authorization: optional OAuth token to authenticate
 :statuscode 200: no error
 :statuscode 401: unauthorized request
         """
         logger.info("Revoking task '%s'", taskid)
         terminate = self.get_argument('terminate', default=False, type=bool)
-        self.capp.control.revoke(taskid, terminate=terminate)
+        signal = self.get_argument('signal', default='SIGTERM', type=str)
+        self.capp.control.revoke(taskid, terminate=terminate, signal=signal)
         self.write(dict(message="Revoked '%s'" % taskid))
 
 

--- a/tests/unit/api/test_control.py
+++ b/tests/unit/api/test_control.py
@@ -136,7 +136,8 @@ class TaskControlTests(AsyncHTTPTestCase):
         r = self.post('/api/task/revoke/test', body={})
         self.assertEqual(200, r.code)
         celery.control.revoke.assert_called_once_with('test',
-                                                      terminate=False)
+                                                      terminate=False,
+                                                      signal='SIGTERM')
 
     def test_terminate(self):
         celery = self._app.capp
@@ -144,4 +145,6 @@ class TaskControlTests(AsyncHTTPTestCase):
         r = self.post('/api/task/revoke/test', body={'terminate': True})
         self.assertEqual(200, r.code)
         celery.control.revoke.assert_called_once_with('test',
-                                                      terminate=True)
+                                                      terminate=True,
+                                                      signal='SIGTERM')
+

--- a/tests/unit/api/test_control.py
+++ b/tests/unit/api/test_control.py
@@ -148,3 +148,11 @@ class TaskControlTests(AsyncHTTPTestCase):
                                                       terminate=True,
                                                       signal='SIGTERM')
 
+    def test_terminate_signal(self):
+        celery = self._app.capp
+        celery.control.revoke = MagicMock()
+        r = self.post('/api/task/revoke/test', body={'terminate': True, 'signal': 'SIGUSR1'})
+        self.assertEqual(200, r.code)
+        celery.control.revoke.assert_called_once_with('test',
+                                                      terminate=True,
+                                                      signal='SIGUSR1')


### PR DESCRIPTION
This change exposes to the API the optional `signal` parameter to `celery.app.control.revoke`, which, if `terminate` is `True`, causes Celery to terminate the running task with the specified signal. If the signal `SIGUSR1` is used, `celery.exceptions.SoftTimeLimitExceeded` will be raised in the task, allowing the task to carry out custom cleanup actions.