### PR TITLE
solves /tasks endpoint failure

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -75,3 +75,4 @@ Moinuddin Quadri
 John Arnold
 Scott Kruger
 David Schneider
+S M Ahasanul Haque

--- a/flower/views/tasks.py
+++ b/flower/views/tasks.py
@@ -107,7 +107,7 @@ class TasksView(BaseHandler):
 
         time = 'natural-time' if app.options.natural_time else 'time'
         if capp.conf.CELERY_TIMEZONE:
-            time += '-' + capp.conf.CELERY_TIMEZONE
+            time += '-' + str(capp.conf.CELERY_TIMEZONE)
 
         self.render(
             "tasks.html",


### PR DESCRIPTION
In 0.9.2 or later (also in current master), I face a problem that /tasks endpoint fails with 500

with following traceback:
    Traceback (most recent call last):
      File .virtualenvs/test_env/lib/python3.5/site-packages/tornado/web.py, line 1510, in _execute
        result = method(*self.path_args, **self.path_kwargs)
      File .virtualenvs/test_env/lib/python3.5/site-packages/tornado/web.py, line 2898, in wrapper
        return method(self, *args, **kwargs)
      File .virtualenvs/test_env/lib/python3.5/site-packages/flower/views/tasks.py, line 110, in get
        time += '-' + capp.conf.CELERY_TIMEZONE
    TypeError: Can't convert 'EST' object to str implicitly

This commit solves this issue