### PR TITLE
 Limit event routing key to task related events 

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -77,3 +77,4 @@ Scott Kruger
 David Schneider
 S M Ahasanul Haque
 Leo Singer
+Derek Harland

--- a/flower/events.py
+++ b/flower/events.py
@@ -109,6 +109,7 @@ class Events(threading.Thread):
                 with self.capp.connection() as conn:
                     recv = EventReceiver(conn,
                                          handlers={"*": self.on_event},
+                                         routing_key="task.#",
                                          app=self.capp)
                     try_interval = 1
                     recv.capture(limit=None, timeout=None, wakeup=True)


### PR DESCRIPTION
Currently flower will be delivered **all** messages that are published to the `celeryev` exchange.  If the celery event mechanism is also being used to publish other customised event messages, the flower server will currently unnecessarily spammed with them.