### PR TITLE
Added worker status filtering toolbar

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -77,3 +77,4 @@ Scott Kruger
 David Schneider
 S M Ahasanul Haque
 Leo Singer
+Louis-Charles Martin

--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -648,6 +648,7 @@ var flower = (function () {
             scrollX: true,
             scrollY: true,
             scrollCollapse: true,
+            dom: '<"toolbar">frtip',
             ajax: url_prefix() + '/dashboard?json=1',
             order: [
                 [1, "asc"]
@@ -708,6 +709,22 @@ var flower = (function () {
             }, autorefresh * 1000);
         }
 
+        // Filter workers by status
+        $('div.toolbar').html(`
+        <div id="worker-status-radio" class="btn-group span6" data-toggle="buttons-radio">
+            <button class="btn active" class="toggle" value="">All</button>
+            <button class="btn" class="toggle" value="online">Online</button>
+            <button class="btn" class="toggle" value="offline">Offline</button>
+        </div>
+        `)
+
+        $("#worker-status-radio > button ").click(function () {
+            $('#workers-table')
+                .DataTable()
+                .column(1)
+                .search($(this).val())
+                .draw();
+        });
     });
 
     $(document).ready(function () {


### PR DESCRIPTION
With cloud native apps, worker are sometimes intended to have a short life and so the fact that we always see the dead workers as "offline" in the dashboard is kind of anoying. As I've seen it has been proposed (but refused)  to have the [ability to remove offline workers](https://github.com/mher/flower/issues/604) with the [PR 649](https://github.com/mher/flower/pull/649), which was determined to be too intrusive.

I propose a simple filter from radio buttons inserted into the datatable toolbar, which is blending with the current UI, easy to use and is of great use when we want to check either the "dead" or the "live" workers.