### PR TITLE
Make dropdown font colour white instead of grey

### DIFF
--- a/flower/static/css/flower.css
+++ b/flower/static/css/flower.css
@@ -229,3 +229,10 @@
   width: 100%;
   display: inline-block;
 }
+
+/* Modify bootstrap dropdown menu to have white font colour instead of
+ * gray (recall that the background is green) */
+.nav-collapse .nav > li > a,
+.nav-collapse .dropdown-menu a {
+  color: #ffffff;
+}


### PR DESCRIPTION
Currently when the viewport for Flower is small the dropdown menu looks like this:

https://i.imgur.com/pAVgi2k.png

It's an eyesore reading the grey font on the green background. This pull request changes the font colours to white:

https://i.imgur.com/WrhKnqs.png