### PR TITLE
WIP: elasticsearch history support

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -305,3 +305,48 @@ purge_offline_workers
 Time (in seconds) after which offline workers are automatically removed from dashboard.
 
 If omitted, offline workers remain on the dashboard.
+
+.. _elasticsearch:
+
+elasticsearch
+~~~~~~~~~~~~~
+
+Signals the process that it should use elasticsearch for history
+
+
+.. _elasticsearch_index_bulk_size:
+
+elasticsearch_index_bulk_size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+How many documents will the elasticsearch indexer allow in a single bulk index API call.
+
+.. _elasticsearch_index_timeout:
+
+elasticsearch_index_timeout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+How long should the background thread wait for the queue to fill up to elasticsearch_index_bulk_size
+
+.. _elasticsearch_day_retention:
+
+elasticsearch_day_retention
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For projects that require data retention management, this will specify how many days can have indexes at once.
+
+So if the value is 21, then any indexes older than 21 days will be deleted. This happens at startup and on day change.
+
+.. _elasticsearch_url:
+
+elasticsearch_url
+~~~~~~~~~~~~~~~~~
+
+Which URL is elasticsearch at?
+
+.. _elasticsearch_dashboard:
+
+elasticsearch_dashboard
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Will the dashboard initially get its counter values from elasticsearch?

--- a/flower/__indexer__.py
+++ b/flower/__indexer__.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+from flower.command import IndexerCommand
+from flower.utils import bugreport
+
+
+def main():
+    try:
+        flower = IndexerCommand()
+        flower.execute_from_commandline()
+    except:
+        import sys
+        print(bugreport(app=flower.app), file=sys.stderr)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/flower/__init__.py
+++ b/flower/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (1, 0, 1)
+VERSION = (1, 0, 1, 1)
 __version__ = '.'.join(map(str, VERSION)) + '-dev'

--- a/flower/api/elasticsearch_history.py
+++ b/flower/api/elasticsearch_history.py
@@ -1,0 +1,104 @@
+from __future__ import absolute_import
+
+import logging
+
+from tornado import web
+
+try:
+    from elasticsearch import Elasticsearch, TransportError
+except ImportError:
+    Elasticsearch = None
+    TransportError = None
+
+from tornado.web import HTTPError
+
+from ..options import options
+
+from ..views import BaseHandler
+
+logger = logging.getLogger(__name__)
+
+
+class ElasticSearchHistoryHandler(BaseHandler):
+    def __init__(self):
+        elasticsearch_url = options.elasticsearch_url
+        if elasticsearch_url:
+            self.es = Elasticsearch([elasticsearch_url, ])
+        else:
+            self.es = None
+
+    @web.authenticated
+    def post(self, index_name=None):
+        index_name = index_name or 'task'
+        try:
+            self.es.indices.refresh(index_name)
+        except TransportError as e:
+            raise HTTPError(400, 'Invalid option: {}'.format(e))
+        else:
+            response = u'Successful refresh on index: {}'.format(index_name)
+            self.write(response)
+
+
+class AlternativeBackendError(Exception):
+    pass
+
+
+def list_tasks_elastic_search(argument_getter):
+    from elasticsearch import Elasticsearch, TransportError
+
+    elasticsearch_url = options.elasticsearch_url
+
+    es = Elasticsearch([elasticsearch_url, ])
+    limit = argument_getter.get_argument('limit', None)
+    worker = argument_getter.get_argument('workername', None)
+    task_name = argument_getter.get_argument('taskname', None)
+    state = argument_getter.get_argument('state', None)
+    received_start = argument_getter.get_argument('received_start', None)
+    received_end = argument_getter.get_argument('received_end', None)
+    started_start = argument_getter.get_argument('started_start', None)
+    started_end = argument_getter.get_argument('started_end', None)
+    root_id = argument_getter.get_argument('root_id', None)
+    parent_id = argument_getter.get_argument('parent_id', None)
+    runtime_lt = argument_getter.get_argument('runtime_lt', None)
+    runtime_gt = argument_getter.get_argument('runtime_gt', None)
+    result = []
+    limit = limit and int(limit)
+    worker = worker if worker != 'All' else None
+    task_name = task_name if task_name != 'All' else None
+    state = state if state != 'All' else None
+    from elasticsearch_dsl import Search
+    from elasticsearch_dsl.query import Term, Range
+    s = Search(using=es, index='task')
+    try:
+        if worker:
+            s = s.filter(Term(hostname=worker))
+        if type:
+            s = s.filter(Term(name=task_name))
+        if state:
+            s = s.filter(Term(state=state))
+        if root_id:
+            s = s.filter(Term(root_id=root_id))
+        if parent_id:
+            s = s.filter(Term(parent_id=parent_id))
+        if received_start:
+            s = s.filter(Range(received_time=dict(gt=received_start)))
+        if received_end:
+            s = s.filter(Range(received_time=dict(lt=received_end)))
+        if started_start:
+            s = s.filter(Range(started_time=dict(gt=started_start)))
+        if started_end:
+            s = s.filter(Range(started_time=dict(lt=started_end)))
+        if runtime_lt is not None:
+            s = s.query(Range(runtime=dict(lt=float(runtime_lt))))
+        if runtime_gt is not None:
+            s = s.query(Range(runtime=dict(gt=float(runtime_gt))))
+        if limit is not None:
+            s = s.extra(size=limit)
+        hit_dicts = s.execute().hits.hits
+        for hit_dict in hit_dicts:
+            result.append((hit_dict['_id'], hit_dict['_source']))
+    except TransportError as e:
+        logger.warning("Issue querying task API via Elasticsearch", exc_info=True)
+        raise AlternativeBackendError()
+    else:
+        return result

--- a/flower/elasticsearch_events.py
+++ b/flower/elasticsearch_events.py
@@ -1,0 +1,363 @@
+from __future__ import absolute_import
+from __future__ import with_statement
+
+import json
+import time
+import logging
+import threading
+import collections
+import traceback
+from datetime import datetime, timedelta, date
+
+from logging import config
+
+import elasticsearch
+import pytz
+from elasticsearch import Elasticsearch, RequestsHttpConnection, TransportError, ElasticsearchException
+from elasticsearch.helpers import bulk
+
+
+from celery.events.state import State
+
+from flower.events import Events
+from . import api
+
+from .options import options
+
+
+try:
+    from collections import Counter
+except ImportError:
+    from .utils.backports.collections import Counter
+
+
+logger = logging.getLogger(__name__)
+try:
+    import queue
+except:
+    import Queue as queue
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'class': 'flower.logging_utils.CeleryOneLineExceptionFormatter',
+            'format': '%(levelname)s %(asctime)s %(funcName)s %(module)s %(lineno)d %(message)s'
+        },
+    },
+    'handlers': {
+        'task_logger_file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.TimedRotatingFileHandler',
+            'filename': 'task_logger.log',
+            'formatter': 'verbose',
+            'when': 'midnight',
+            'interval': 1,
+            'backupCount': 30,
+            'utc': True,
+        },
+        'stream': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
+    },
+    'loggers': {
+        'task_logger': {
+            'handlers': ['task_logger_file', 'stream', ],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+    },
+}
+config.dictConfig(LOGGING)
+
+logger = logging.getLogger('task_logger')
+ELASTICSEARCH_URL = options.elasticsearch_url
+ES_INDEX_TIMEOUT = options.elasticsearch_index_timeout
+ES_INDEX_BULK_SIZE = options.elasticsearch_index_bulk_size
+ES_DAY_RETENTION = options.elasticsearch_day_retention
+
+
+ES_CLIENT = Elasticsearch(
+    [ELASTICSEARCH_URL],
+    connection_class=RequestsHttpConnection
+)
+
+INDICES_CLIENT = ES_CLIENT.indices
+# Index name states the day in which it was created -- not how long it is around for
+index_name = 'task-{}'.format(datetime.utcnow().date().isoformat())
+
+body = {
+    'properties': {
+        'hostname': {'type': 'keyword', },
+        'worker': {'type': 'keyword', },
+        'clock': {'type': 'integer', },
+        'args': {'type': 'keyword', },
+        'kwargs': {'type': 'keyword', },
+        'timestamp_time': {'type': 'date', },
+        'timestamp': {'type': 'float', },
+        'root_id': {'type': 'keyword', },
+        'root': {'type': 'keyword', },
+        'parent_id': {'type': 'keyword', },
+        'parent': {'type': 'keyword', },
+        'name': {'type': 'keyword', },
+        'result': {'type': 'keyword', },
+        'state': {'type': 'keyword', },
+        'eta': {'type': 'date', },
+        'received': {'type': 'float', },
+        'retries': {'type': 'integer', },
+        'received_time': {
+            "type": "date",
+        },
+        'expires': {'type': 'date', },
+        'revoked': {'type': 'float', },
+        'revoked_time': {
+            "type": "date",
+        },
+        'retried': {'type': 'float', },
+        'retried_time': {
+            "type": "date",
+        },
+        'started': {'type': 'float', },
+        'started_time': {
+            "type": "date",
+        },
+        'failed': {'type': 'float', },
+        'failed_time': {
+            "type": "date",
+        },
+        'succeeded': {'type': 'float', },
+        'succeeded_time': {
+            "type": "date",
+        },
+        'runtime': {'type': 'float', },
+        'info': {'type': 'text', },
+        'traceback': {'type': 'text', },
+        'exception': {'type': 'text', },
+        '_fields': {'type': 'keyword', },
+        'children': {'type': 'keyword', },
+    }
+}
+
+es_queue = queue.Queue()
+
+
+def es_consumer():
+    es_buffer = []
+    t = threading.currentThread()
+    while getattr(t, "do_run", True):
+        start_time = int(time.time())
+        try:
+            while len(es_buffer) < ES_INDEX_BULK_SIZE:
+                es_buffer.append(es_queue.get(timeout=ES_INDEX_TIMEOUT))
+                es_queue.task_done()
+                got_task_time = int(time.time())
+                if got_task_time - start_time >= ES_INDEX_TIMEOUT:
+                    raise queue.Empty
+        except queue.Empty:
+            pass
+        if es_buffer:
+            for try_idx in range(5):
+                # should consider implementing retry logic (outside of what the ES library uses)
+                try:
+                    bulk(actions=es_buffer, client=ES_CLIENT, stats_only=True)
+                except (elasticsearch.ConnectionError, elasticsearch.ConnectionTimeout, ):
+                    time.sleep(pow(2, try_idx))
+                    logger.warning(traceback.format_exc())
+                except elasticsearch.helpers.BulkIndexError:
+                    time.sleep(pow(2, try_idx))
+                    logger.warning(traceback.format_exc())
+                    break
+                except Exception:
+                    es_buffer[:] = []
+                    logger.warning(traceback.format_exc())
+                    break
+                else:
+                    es_buffer[:] = []
+                    break
+            # Can enable the sleep in case it seems like we're writing into ES too frequently
+            # time.sleep(0.5)
+
+
+es_thread = threading.Thread(target=es_consumer)
+es_thread.daemon = True
+
+
+def send_to_elastic_search(state, event):
+    # task name is sent only with -received event, and state
+    # will keep track of this for us.
+    if not event['type'].startswith('task-'):
+        return
+    task = state.tasks.get(event['uuid'])
+    received_time = task.received
+    succeeded_time = task.succeeded
+    start_time = task.started
+
+    # potentially use the sched module to change it via native python logic
+    current_date = datetime.now(tz=pytz.utc).date()
+    active_index_name = 'task-{}'.format(current_date.isoformat())
+    global index_name
+    if active_index_name != index_name:
+        try:
+            INDICES_CLIENT.create(index=active_index_name)
+            INDICES_CLIENT.put_alias('task-*', 'task')
+            INDICES_CLIENT.put_mapping(
+                doc_type='task',
+                body=body,
+                index=active_index_name
+            )
+            index_name = active_index_name
+        except TransportError:
+            logger.warning("Issue creating or putting alias or mapping", traceback.format_exc())
+        else:
+            try:
+                deleted = delete_old_elasticsearch_indices(current_date, ES_DAY_RETENTION)
+                logger.info("Deleted the following older indices from day retention: "
+                            "{day_retention}, "
+                            "indices: {deleted}".format(day_retention=ES_DAY_RETENTION, deleted=deleted))
+            except ElasticsearchException:
+                logger.warning("Issue deleting older indices", exc_info=True)
+
+    doc_body = {
+        'hostname': task.hostname,
+        'worker': task.hostname if task.worker else None,
+        'exchange': task.exchange,
+        'retries': task.retries,
+        'routing_key': task.routing_key,
+        'args': task.args,
+        'kwargs': task.kwargs,
+        'name': task.name,
+        'clock': task.clock,
+        'children': str(task.children) if task.children is not None else None,
+        'expires': task.expires if task.expires else task.expires,
+        'eta': task.eta,
+        'state': task.state,
+        'received': received_time,
+        'received_time': datetime.utcfromtimestamp(received_time).replace(tzinfo=pytz.utc) if received_time else None,
+        'retried': task.retried,
+        'retried_time': datetime.utcfromtimestamp(task.retried).replace(tzinfo=pytz.utc) if task.retried else None,
+        'started': start_time,
+        'started_time': datetime.utcfromtimestamp(start_time).replace(tzinfo=pytz.utc) if start_time else None,
+        'succeeded': succeeded_time,
+        'succeeded_time': datetime.utcfromtimestamp(succeeded_time).replace(
+            tzinfo=pytz.utc) if succeeded_time else None,
+        'revoked': task.revoked,
+        'revoked_time': datetime.utcfromtimestamp(task.revoked).replace(tzinfo=pytz.utc) if task.revoked else None,
+        'failed': task.failed,
+        'failed_time': datetime.utcfromtimestamp(task.failed).replace(tzinfo=pytz.utc) if task.failed else None,
+        'info': json.dumps(task.info()),
+        'result': task.result,
+        'root_id': task.root_id,
+        'root': str(task.root) if task.root else None,
+        'runtime': task.runtime,
+        'timestamp': task.timestamp,
+        'timestamp_time': datetime.utcfromtimestamp(task.timestamp).replace(tzinfo=pytz.utc) if task.timestamp else None,
+        'exception': task.exception,
+        'traceback': task.traceback,
+        'parent_id': task.parent_id,
+        'parent': str(task.parent) if task.parent else None,
+        '_fields': task._fields,
+    }
+    try:
+        doc_body['_type'] = 'task'
+        doc_body['_op_type'] = 'index'
+        doc_body['_index'] = index_name
+        doc_body['_id'] = task.uuid
+        es_queue.put(doc_body)
+    except Exception:
+        logger.info('{name}[{uuid}] worker: {worker}, received: {received}, '
+                    'started: {started}, succeeded: {succeeded}, info={info}'.format(name=task.name,
+                                                                                     uuid=task.uuid,
+                                                                                     worker=task.hostname,
+                                                                                     info=task.info(),
+                                                                                     received=received_time,
+                                                                                     started=start_time,
+                                                                                     succeeded=succeeded_time, ))
+
+
+def delete_old_elasticsearch_indices(current_date, day_cut_off):
+    if day_cut_off is None:
+        return None
+    date_cut_off = current_date - timedelta(days=day_cut_off)
+    indices_return = ES_CLIENT.cat.indices(index="task", format="json", h="index")
+    indices_return = [
+        item["index"] for item in indices_return if
+        date(
+            year=int(item["index"].split("-")[1]),
+            month=int(item["index"].split("-")[2]),
+            day=int(item["index"].split("-")[3]))
+        < date_cut_off
+    ]
+    if indices_return:
+        return {"indices": indices_return, "response": ES_CLIENT.indices.delete(index=",".join(indices_return))}
+
+
+class EventsState(State):
+    # EventsState object is created and accessed only from ioloop thread
+
+    def __init__(self, *args, **kwargs):
+        super(EventsState, self).__init__(*args, **kwargs)
+        self.counter = collections.defaultdict(Counter)
+
+    def event(self, event):
+        worker_name = event['hostname']
+        event_type = event['type']
+
+        if not event['type'].startswith('task-'):
+            return
+
+        # Send event to api subscribers (via websockets)
+        classname = api.events.getClassName(event_type)
+        cls = getattr(api.events, classname, None)
+        if cls:
+            cls.send_message(event)
+
+        # Save the event
+        super(EventsState, self).event(event)
+        send_to_elastic_search(self, event)
+
+
+class IndexerEvents(Events):
+    events_enable_interval = 5000
+
+    def __init__(self, capp, db=None, persistent=False,
+                 enable_events=True, io_loop=None, **kwargs):
+
+        super(IndexerEvents, self).__init__(capp=capp, db=db, persistent=persistent,
+                                            enable_events=enable_events, io_loop=io_loop,
+                                            **kwargs)
+        try:
+            INDICES_CLIENT.create(index=index_name)
+        except TransportError as te:
+            if te.error in ['index_already_exists_exception', 'resource_already_exists_exception']:
+                pass
+            else:
+                logger.warning("Elastic search occurred, "
+                               "may be bad: {}".format(traceback.format_exc()))
+        try:
+            INDICES_CLIENT.put_mapping(
+                doc_type='task',
+                body=body,
+                index=index_name
+            )
+        except TransportError:
+            logger.warning("Elastic search put mapping error (may be bad)", exc_info=True)
+        try:
+            if INDICES_CLIENT.exists(index=index_name):
+                INDICES_CLIENT.put_alias('task-*', 'task')
+        except TransportError:
+            logger.warning("Elastic search exists/alias put error", exc_info=True)
+
+        try:
+            current_date = datetime.now(tz=pytz.utc).date()
+            deleted = delete_old_elasticsearch_indices(current_date, ES_DAY_RETENTION)
+            logger.info("Deleted the following older indices from day retention: "
+                        "{day_retention}, "
+                        "indices: {deleted}".format(day_retention=ES_DAY_RETENTION, deleted=deleted))
+        except ElasticsearchException:
+            logger.warning("Issue deleting older indices.", exc_info=True)
+
+        self.state = EventsState(**kwargs)

--- a/flower/events.py
+++ b/flower/events.py
@@ -17,7 +17,8 @@ from celery.events.state import State
 
 from . import api
 
-from collections import Counter
+from .options import options
+from collections import defaultdict, Counter
 from concurrent.futures import ThreadPoolExecutor
 
 from prometheus_client import Counter as PrometheusCounter, Histogram
@@ -42,10 +43,41 @@ class EventsState(State):
         worker_name = event['hostname']
         event_type = event['type']
 
-        self.counter[worker_name][event_type] += 1
+        if not self.counter[worker_name] and options.elasticsearch_dashboard is True:
+            from elasticsearch import Elasticsearch
+            ELASTICSEARCH_URL = options.elasticsearch_url
+            es = Elasticsearch([ELASTICSEARCH_URL, ])
+            from elasticsearch_dsl import Search, MultiSearch
+            from elasticsearch_dsl.query import Term
+            ms = MultiSearch(using=es, index="task")
+            s = Search(using=es, index='task')
+            ms = ms.add(s.filter(Term(state='RECEIVED') & Term(hostname=worker_name)).extra(size=0))
+            ms = ms.add(s.filter(Term(state='STARTED') & Term(hostname=worker_name)).extra(size=0))
+            ms = ms.add(s.filter(Term(state='SUCCESS') & Term(hostname=worker_name)).extra(size=0))
+            ms = ms.add(s.filter(Term(state='FAILED') & Term(hostname=worker_name)).extra(size=0))
+            ms = ms.add(s.filter(Term(state='RETRIED') & Term(hostname=worker_name)).extra(size=0))
+            responses = ms.execute()
+            task_event_keys = ["task-received", "task-started", "task-succeeded", "task-failed", "task-retried"]
+            tasks_info = defaultdict(int)
+            for event_type, resp in zip(task_event_keys, responses):
+                tasks_info[event_type] += resp.hits.total
+            processed = tasks_info["task-received"]
+            started = tasks_info["task-started"]
+            succeeded = tasks_info["task-succeeded"]
+            failed = tasks_info["task-failed"]
+            retried = tasks_info["task-retried"]
+            self.counter[worker_name]['task-received'] = processed + started + succeeded + failed + retried
+            self.counter[worker_name]['task-started'] = started
+            self.counter[worker_name]['task-succeeded'] = succeeded
+            self.counter[worker_name]['task-retried'] = retried
+            self.counter[worker_name]['task-failed'] = failed
+            if not event_type.startswith('task-'):
+                self.counter[worker_name][event_type] += 1
+        else:
+            self.counter[worker_name][event_type] += 1
 
         if event_type.startswith('task-'):
-            task_id = event['uuid']
+            task_id = event.get('uuid')
             task_name = event.get('name', '')
             if not task_name and task_id in self.tasks:
                 task_name = self.tasks[task_id].name or ''
@@ -63,6 +95,12 @@ class EventsState(State):
 
         # Save the event
         super(EventsState, self).event(event)
+
+        # from .elasticsearch_history import send_to_elastic_search
+        # try:
+        #     send_to_elastic_search(self, event)
+        # except Exception as e:
+        #     print(e)
 
 
 class Events(threading.Thread):

--- a/flower/indexer_app.py
+++ b/flower/indexer_app.py
@@ -1,0 +1,41 @@
+import celery
+from tornado import ioloop
+
+from flower.options import default_options
+
+
+class IndexerApp(object):
+    def __init__(self, options=None, capp=None, events=None, io_loop=None, **kwargs):
+        super(IndexerApp, self).__init__()
+        self.options = options or default_options
+        self.io_loop = ioloop.IOLoop.instance()
+
+        self.capp = capp or celery.Celery()
+        from flower.elasticsearch_events import IndexerEvents, es_thread
+        self.es_thread = es_thread
+        self.events = events or IndexerEvents(
+            self.capp, db=self.options.db,
+            persistent=self.options.persistent,
+            enable_events=self.options.enable_events,
+            io_loop=self.io_loop,
+            max_workers_in_memory=self.options.max_workers,
+            max_tasks_in_memory=self.options.max_tasks)
+        self.started = False
+
+    def start(self):
+        self.events.start()
+        self.es_thread.start()
+        self.started = True
+        self.io_loop.start()
+
+    def stop(self):
+        if self.started:
+            self.events.stop()
+            self.es_thread.do_run = False
+            self.es_thread.join(timeout=10)
+            self.started = False
+
+    @property
+    def transport(self):
+        return getattr(self.capp.connection().transport,
+                       'driver_type', None)

--- a/flower/logging_utils.py
+++ b/flower/logging_utils.py
@@ -1,0 +1,19 @@
+import logging
+
+
+class CeleryOneLineExceptionFormatter(logging.Formatter):
+    """
+    Special logging formatter mostly for Celery, to make exceptions on 1 line.
+    """
+    def formatException(self, exc_info):
+        """
+        Format an exception so that it prints on a single line.
+        """
+        result = super(CeleryOneLineExceptionFormatter, self).formatException(exc_info)
+        return repr(result)  # or format into one line however you want to
+
+    def format(self, record):
+        s = super(CeleryOneLineExceptionFormatter, self).format(record)
+        if record.exc_text or record.levelno >= logging.ERROR:
+            s = s.replace('\n', '') + '|'
+        return s

--- a/flower/options.py
+++ b/flower/options.py
@@ -65,6 +65,12 @@ define("tasks_columns", type=str,
 define("auth_provider", default='flower.views.auth.GoogleAuth2LoginHandler',
        help="auth handler class")
 define("url_prefix", type=str, help="base url prefix")
+define("elasticsearch", type=bool, default=False)
+define("elasticsearch_index_bulk_size", type=int, default=200)
+define("elasticsearch_index_timeout", type=int, default=10)
+define("elasticsearch_day_retention", type=int, default=21)
+define("elasticsearch_url", type=str, default="http://localhost:9200/")
+define("elasticsearch_dashboard", type=bool, default=False)
 
 # deprecated options
 define("inspect", default=False, help="inspect workers", type=bool)

--- a/flower/urls.py
+++ b/flower/urls.py
@@ -6,6 +6,7 @@ from .api import events
 from .api import control
 from .api import tasks
 from .api import workers
+from .api import elasticsearch_history
 from .views import auth
 from .views import monitor
 from .views.broker import BrokerView
@@ -68,6 +69,8 @@ handlers = [
     (r"/api/task/events/task-custom/(.*)", events.TaskCustom),
     # Metrics
     (r"/metrics", monitor.Metrics),
+    # Elastic search
+    (r"/api/es/refresh/(.*)", elasticsearch_history.ElasticSearchHistoryHandler),
     # Static
     (r"/static/(.*)", StaticFileHandler,
      {"path": settings['static_path']}),

--- a/flower/utils/search.py
+++ b/flower/utils/search.py
@@ -1,9 +1,11 @@
+import datetime
 import re
+import time
 
 from kombu.utils.encoding import safe_str
 
 
-def parse_search_terms(raw_search_value):
+def parse_search_terms(raw_search_value, find_time_keys=False):
     search_regexp = r'(?:[^\s,"]|"(?:\\.|[^"])*")+'  # splits by space, ignores space in quotes
     if not raw_search_value:
         return {}
@@ -11,12 +13,17 @@ def parse_search_terms(raw_search_value):
     for query_part in re.findall(search_regexp, raw_search_value):
         if not query_part:
             continue
+        find_any = True
         if query_part.startswith('result:'):
             parsed_search['result'] = preprocess_search_value(query_part[len('result:'):])
         elif query_part.startswith('args:'):
             if 'args' not in parsed_search:
                 parsed_search['args'] = []
             parsed_search['args'].append(preprocess_search_value(query_part[len('args:'):]))
+        elif query_part.startswith('taskname:'):
+            if 'taskname' not in parsed_search:
+                parsed_search['taskname'] = []
+            parsed_search['taskname'].append(preprocess_search_value(query_part[len('taskname:'):]))
         elif query_part.startswith('kwargs:'):
             if 'kwargs'not in parsed_search:
                 parsed_search['kwargs'] = {}
@@ -26,7 +33,61 @@ def parse_search_terms(raw_search_value):
             if 'state' not in parsed_search:
                 parsed_search['state'] = []
             parsed_search['state'].append(preprocess_search_value(query_part[len('state:'):]))
-        else:
+        elif query_part.startswith('es:'):
+            parsed_search['es'] = preprocess_search_value(query_part[len('es:'):])
+        elif query_part.startswith('uuid:'):
+            parsed_search['uuid'] = preprocess_search_value(query_part[len('uuid:'):])
+        elif query_part.startswith('runtime_lt:'):
+            parsed_search['runtime_lt'] = preprocess_search_value(query_part[len('runtime_lt:'):])
+        elif query_part.startswith('runtime_gt:'):
+            parsed_search['runtime_gt'] = preprocess_search_value(query_part[len('runtime_gt:'):])
+        elif query_part.startswith('root_id:'):
+            parsed_search['root_id'] = preprocess_search_value(query_part[len('root_id:'):])
+        elif query_part.startswith('parent_id:'):
+            parsed_search['parent_id'] = preprocess_search_value(query_part[len('parent_id:'):])
+        if parsed_search:
+            find_any = False
+        if find_time_keys:
+            def convert(x):
+                try:
+                    if x.count(":") == 2:
+                        if x.count("."):
+                            # does not return fractional second information, but at least
+                            # we can "support" it being passed in, as opposed to ignoring it
+                            return time.mktime(
+                                datetime.datetime.strptime(x, '%Y-%m-%d %H:%M:%S.%f').timetuple()
+                            )
+                        else:
+                            return time.mktime(
+                                datetime.datetime.strptime(x, '%Y-%m-%d %H:%M:%S').timetuple()
+                            )
+                    else:
+                        return time.mktime(
+                            datetime.datetime.strptime(x, '%Y-%m-%d %H:%M').timetuple()
+                        )
+                except ValueError:
+                    return ""
+            if query_part.startswith('received_start'):
+                received_start = preprocess_search_value(query_part[len('received_start:'):])
+                if received_start:
+                    parsed_search['received_start'] = convert(received_start)
+                    find_any = False
+            if query_part.startswith('received_end'):
+                received_end = preprocess_search_value(query_part[len('received_end:'):])
+                if received_end:
+                    parsed_search['received_end'] = convert(received_end)
+                    find_any = False
+            if query_part.startswith('started_start'):
+                started_start = preprocess_search_value(query_part[len('started_start:'):])
+                if started_start:
+                    parsed_search['started_start'] = convert(started_start)
+                    find_any = False
+            if query_part.startswith('started_end'):
+                started_end = preprocess_search_value(query_part[len('started_end:'):])
+                if started_end:
+                    parsed_search['started_end'] = convert(started_end)
+                    find_any = False
+        if find_any:
             parsed_search['any'] = preprocess_search_value(query_part)
     return parsed_search
 
@@ -34,11 +95,20 @@ def parse_search_terms(raw_search_value):
 def satisfies_search_terms(task, search_terms):
     any_value_search_term = search_terms.get('any')
     result_search_term = search_terms.get('result')
+    task_name_search_term = search_terms.get('taskname')
     args_search_terms = search_terms.get('args')
     kwargs_search_terms = search_terms.get('kwargs')
     state_search_terms = search_terms.get('state')
+    runtime_lt = search_terms.get("runtime_lt")
+    runtime_gt = search_terms.get("runtime_gt")
 
-    if not any([any_value_search_term, result_search_term, args_search_terms, kwargs_search_terms, state_search_terms]):
+    activated_terms = [
+        any_value_search_term, result_search_term,
+        task_name_search_term, args_search_terms,
+        kwargs_search_terms, state_search_terms,
+        runtime_lt, runtime_gt,
+    ]
+    if not any(activated_terms):
         return True
 
     terms = [
@@ -48,10 +118,13 @@ def satisfies_search_terms(task, search_terms):
                           task.worker.hostname if task.worker else None,
                           task.args, task.kwargs, safe_str(task.result)])),
         result_search_term and result_search_term in task.result,
+        task_name_search_term and task_name_search_term in task.name,
         kwargs_search_terms and all(
             stringified_dict_contains_value(k, v, task.kwargs) for k, v in kwargs_search_terms.items()
         ),
-        args_search_terms and task_args_contains_search_args(task.args, args_search_terms)
+        args_search_terms and task_args_contains_search_args(task.args, args_search_terms),
+        runtime_lt is not None and task.runtime is not None and float(runtime_lt) > task.runtime,
+        runtime_gt is not None and task.runtime is not None and float(runtime_gt) < task.runtime,
     ]
     return any(terms)
 

--- a/flower/utils/tasks.py
+++ b/flower/utils/tasks.py
@@ -8,7 +8,8 @@ from celery.events.state import Task
 
 def iter_tasks(events, limit=None, type=None, worker=None, state=None,
                sort_by=None, received_start=None, received_end=None,
-               started_start=None, started_end=None, search=None):
+               started_start=None, started_end=None, search=None,
+               root_id=None, parent_id=None, runtime_lt=None, runtime_gt=None):
     i = 0
     tasks = events.state.tasks_by_timestamp()
     if sort_by is not None:
@@ -25,6 +26,14 @@ def iter_tasks(events, limit=None, type=None, worker=None, state=None,
         if worker and task.worker and task.worker.hostname != worker:
             continue
         if state and task.state != state:
+            continue
+        if root_id and task.root_id != root_id:
+            continue
+        if parent_id and task.parent_id != parent_id:
+            continue
+        if runtime_lt is not None and task.runtime is not None and runtime_lt < task.runtime:
+            continue
+        if runtime_gt is not None and task.runtime is not None and runtime_gt > task.runtime:
             continue
         if received_start and task.received and\
                 task.received < convert(received_start):

--- a/flower/views/tasks.py
+++ b/flower/views/tasks.py
@@ -1,10 +1,14 @@
+import datetime
+import time
 from functools import total_ordering
 import copy
 import logging
 
+from flower.utils.search import parse_search_terms
 
 from tornado import web
 
+from ..options import options
 from ..views import BaseHandler
 from ..utils.tasks import iter_tasks, get_task_by_id, as_dict
 
@@ -12,9 +16,44 @@ logger = logging.getLogger(__name__)
 
 
 class TaskView(BaseHandler):
+    def __init__(self, *args, **kwargs):
+        self.use_es = options.elasticsearch
+        self.elasticsearch_url = options.elasticsearch_url
+        if self.use_es:
+            from elasticsearch.client import Elasticsearch
+            self.es_client = Elasticsearch([self.elasticsearch_url, ])
+        else:
+            self.es_client = None
+        super(TaskView, self).__init__(*args, **kwargs)
+
     @web.authenticated
     def get(self, task_id):
-        task = get_task_by_id(self.application.events, task_id)
+        use_es = self.get_argument('es', type=bool, default=self.use_es)
+        if use_es:
+            from elasticsearch.client import Elasticsearch
+            from elasticsearch_dsl.query import Match
+            from elasticsearch.exceptions import TransportError
+            try:
+                es_client = self.es_client
+                if es_client.indices.exists('task'):
+                    from elasticsearch_dsl import Search
+                    from elasticsearch_dsl.query import Wildcard
+                    es_s = Search(using=es_client, index='task')
+                    for hit in es_s.query(Match(_id=task_id)):
+                        task = hit
+                        task.uuid = task_id
+                        task.worker = type('worker', (), {})()
+                        task.worker.hostname = task.hostname
+                        break
+                    else:
+                        use_es = False
+                else:
+                    use_es = False
+            except TransportError:
+                logger.exception('Issue getting elastic search task data; falling back to in memory')
+                use_es = False
+        if not use_es:
+            task = get_task_by_id(self.application.events, task_id)
 
         if task is None:
             raise web.HTTPError(404, "Unknown task '%s'" % task_id)
@@ -42,7 +81,25 @@ class Comparable(object):
             return self.value is None
 
 
+class DoNotUseElasticSearchHistoryError(Exception):
+    pass
+
+
 class TasksDataTable(BaseHandler):
+    def __init__(self, *args, **kwargs):
+        if options.elasticsearch:
+            from kombu.utils.functional import LRUCache
+            self.query_cache = LRUCache(limit=1000)
+            self.use_es = True
+            self.elasticsearch_url = options.elasticsearch_url
+            from elasticsearch.client import Elasticsearch
+            self.es_client = Elasticsearch([self.elasticsearch_url, ])
+        else:
+            self.query_cache = None
+            self.elasticsearch_url = None
+            self.use_es = False
+        super(TasksDataTable, self).__init__(*args, **kwargs)
+
     @web.authenticated
     def get(self):
         app = self.application
@@ -50,34 +107,189 @@ class TasksDataTable(BaseHandler):
         start = self.get_argument('start', type=int)
         length = self.get_argument('length', type=int)
         search = self.get_argument('search[value]', type=str)
-
+        use_es = bool(self.use_es)
         column = self.get_argument('order[0][column]', type=int)
         sort_by = self.get_argument('columns[%s][data]' % column, type=str)
         sort_order = self.get_argument('order[0][dir]', type=str) == 'desc'
+        if use_es:
+            from elasticsearch.client import Elasticsearch, TransportError
+            es_client = self.es_client
+            try:
+                from elasticsearch_dsl import Search
+                from elasticsearch_dsl.query import Wildcard, Match, Terms, Term, Range
+                es_s = Search(using=es_client, index='task')
+                if search:
+                    search_terms = parse_search_terms(search or {}, find_time_keys=True)
+                    if search_terms:
+                        if 'es' in search_terms:
+                            if search_terms.get('es') == '0':
+                                raise DoNotUseElasticSearchHistoryError()
+                        if 'args' in search_terms:
+                            s_args = search_terms['args']
+                            arg_queries = None
+                            for s_arg in s_args:
+                                if arg_queries is None:
+                                    arg_queries = Wildcard(args='*'+s_arg+'*')
+                                else:
+                                    arg_queries &= Wildcard(args='*'+s_arg+'*')
+                            es_s = es_s.query(arg_queries)
+                        if 'kwargs' in search_terms:
+                            s_args = search_terms['kwargs']
+                            arg_queries = None
+                            for s_arg, s_v_arg in s_args.items():
+                                if arg_queries is None:
+                                    arg_queries = Wildcard(kwargs='*' + s_arg + ': ' + s_v_arg + '*')
+                                else:
+                                    arg_queries &= Wildcard(kwargs='*' + s_arg + ': ' + s_v_arg + '*')
+                            es_s = es_s.query(arg_queries)
+                        if 'result' in search_terms:
+                            es_s = es_s.query(Match(result=search_terms['result']))
+                        if 'taskname' in search_terms:
+                            es_s = es_s.query(Terms(name=search_terms['taskname']))
+                        if 'runtime_lt' in search_terms and search_terms['runtime_lt']:
+                            es_s = es_s.query(Range(runtime=dict(lt=float(search_terms['runtime_lt']))))
+                        if 'runtime_gt' in search_terms and search_terms['runtime_gt']:
+                            es_s = es_s.query(Range(runtime=dict(gt=float(search_terms['runtime_gt']))))
+                        if 'parent_id' in search_terms:
+                            es_s = es_s.filter(Term(parent_id=search_terms['parent_id']))
+                        if 'root_id' in search_terms:
+                            es_s = es_s.filter(Term(root_id=search_terms['root_id']))
+                        if 'received_start' in search_terms:
+                            es_s = es_s.filter(Range(received_time=dict(gt=datetime.datetime.utcfromtimestamp(search_terms['received_start']).isoformat())))
+                        if 'received_end' in search_terms:
+                            es_s = es_s.filter(Range(received_time=dict(lt=datetime.datetime.utcfromtimestamp(search_terms['received_end']).isoformat())))
+                        if 'started_start' in search_terms:
+                            es_s = es_s.filter(Range(started_time=dict(gt=datetime.datetime.utcfromtimestamp(search_terms['started_start']).isoformat())))
+                        if 'started_end' in search_terms:
+                            es_s = es_s.filter(Range(started_time=dict(lt=datetime.datetime.utcfromtimestamp(search_terms['started_end']).isoformat())))
+                        if 'state' in search_terms:
+                            es_s = es_s.query(Terms(state=search_terms['state']))
+                        if search_terms.get('uuid'):
+                            es_s = es_s.query(Term(**{'_id': search_terms['uuid']}))
+                            # if searching by `uuid`, then no need to search by `any`.
+                            search_terms.pop('any', None)
+                        if 'any' in search_terms:
+                            # this is a simple form of the `any` search that flower constructs
+                            es_id_query = es_s.filter(Term(**{'_id': search}))
+                            id_hits = es_id_query.execute().hits.hits
+                            if id_hits:
+                                es_s = es_id_query
+                            else:
+                                es_s = es_s.query(Wildcard(name='*' + search + '*') |
+                                                  Wildcard(hostname='*' + search + '*'))
 
-        def key(item):
-            return Comparable(getattr(item[1], sort_by))
+                # total_records = es_s.count()
+                if sort_by in ('started', 'received', 'succeeded', 'failed', 'revoked', 'timestamp', ):
+                    sort_by += '_time'
+                sorted_tasks = es_s.sort({sort_by: dict(order='asc' if sort_order else 'desc')})
+                filtered_tasks = []
+                # elastic search window for normal pagination is default at 10000
+                # so if we're over 10000, then we need to hand-find the appropriate next value
+                # and to do this we have 1 major way:
+                # using `search_after` (from this value or a previous search_after)
+                # we can efficiently search deeply into elasticsearch
+                #
+                # If it's our first time and we're going way beyond 10000, then we'll use `search_after`
+                # to efficiently get to the proper spot
+                # And if we have the previous start already cached, we'll use that to find the next start
+                if start + length > 10000:
+                    total_tries = 5
+                    cache_value = None
+                    cache_start = None
+                    if self.query_cache:
+                        for start_offset in range(1, 201):
+                            for try_index in range(total_tries):
+                                cache_value = self.query_cache.get((start - (length * start_offset),
+                                                               length, sort_by, sort_order))
+                                if cache_value:
+                                    cache_start = start - (length * start_offset)
+                                    break
+                                else:
+                                    time.sleep(0.001)
+                            if cache_value:
+                                break
+                    # TODO: handle the case where we grab an older cache key and we need to forward to
+                    # the current search context appropriately (people spamming the `Next` button faster than we
+                    # can compute the next one. We can get old ones if they miss the next one)
+                    # We already retry on the current one, but if we miss out and go earlier, then there could be a bug.
+                    if cache_value:
+                        if cache_start < start - length:
+                            # TODO: validate that this will forward us to the correct current start
+                            for idx in range(cache_start + length, start - length, length):
+                                sorted_tasks = es_s.extra(from_=0,
+                                                          size=length, search_after=cache_value).sort(
+                                    {sort_by: 'asc' if sort_order else 'desc'}, {'_uid': 'desc', }
+                                )
+                                cache_value = sorted_tasks.execute().hits.hits[-1]['sort']
+                        sorted_tasks = es_s.extra(from_=0, size=length, search_after=cache_value).sort(
+                            {sort_by: 'asc' if not sort_order else 'desc'}, {'_uid': 'desc', }).execute().hits
+                    else:
+                        last_normal_hits = sorted_tasks.extra(from_=9999, size=1).execute().hits.hits
+                        if last_normal_hits:
+                            last_hit = last_normal_hits[0]
+                            sorted_tasks = es_s.extra(from_=0, size=length,
+                                                      search_after=[last_hit['sort'][0],
+                                                                    'task#' + last_hit['_id']]).sort(
+                                {sort_by: 'asc' if sort_order else 'desc'}, {'_uid': 'desc', })
+                            hits = sorted_tasks.execute().hits.hits
+                            if len(hits) + 10000 < start:
+                                # may be a bug in here where we have no hits because of a logic error in here
+                                # we could get more efficient by forwarding with a higher `length` until we get
+                                # to where we need to be
+                                for idx in range(9999+length, start + length, length):
+                                    hits = sorted_tasks.execute().hits.hits
+                                    sorted_tasks = es_s.extra(from_=0,
+                                                              size=length, search_after=hits[-1]['sort']).sort(
+                                        {sort_by: 'asc' if sort_order else 'desc'}, {'_uid': 'desc', }
+                                    )
+                            sorted_tasks = sorted_tasks.execute().hits
+                else:
+                    sorted_tasks = sorted_tasks.extra(from_=start, size=length).execute().hits
+                last_task = None
+                total_records = sorted_tasks.total
+                for task in sorted_tasks.hits:
+                    task_dict = task.get('_source')
+                    task_dict['uuid'] = task['_id']
+                    if task_dict.get('worker'):
+                        task_dict['worker'] = task_dict['hostname']
+                    else:
+                        task_dict['worker'] = task_dict.get('hostname')
+                    filtered_tasks.append(task_dict)
+                    last_task = task
+                records_filtered = sorted_tasks.total
+                if start + length > 10000:
+                    # may be a bug in here --> last_task may be `None` by mistake
+                    self.query_cache[(start, length, sort_by, sort_order)] = last_task.get('sort')
+            except TransportError:
+                logger.exception('Issue getting elastic search task data; falling back to in memory')
+                use_es = False
+            except DoNotUseElasticSearchHistoryError:
+                use_es = False
+        if not use_es:
+            def key(item):
+                return Comparable(getattr(item[1], sort_by))
 
-        self.maybe_normalize_for_sort(app.events.state.tasks_by_timestamp(), sort_by)
+            self.maybe_normalize_for_sort(app.events.state.tasks_by_timestamp(), sort_by)
+            sorted_tasks = sorted(
+                iter_tasks(app.events, search=search),
+                key=key,
+                reverse=sort_order
+            )
+            total_records = len(sorted_tasks)
 
-        sorted_tasks = sorted(
-            iter_tasks(app.events, search=search),
-            key=key,
-            reverse=sort_order
-        )
+            filtered_tasks = []
+            records_filtered = len(sorted_tasks)
 
-        filtered_tasks = []
+            for task in sorted_tasks[start:start + length]:
+                task_dict = as_dict(self.format_task(task)[1])
+                if task_dict.get('worker'):
+                    task_dict['worker'] = task_dict['worker'].hostname
 
-        for task in sorted_tasks[start:start + length]:
-            task_dict = as_dict(self.format_task(task)[1])
-            if task_dict.get('worker'):
-                task_dict['worker'] = task_dict['worker'].hostname
-
-            filtered_tasks.append(task_dict)
+                filtered_tasks.append(task_dict)
 
         self.write(dict(draw=draw, data=filtered_tasks,
-                        recordsTotal=len(sorted_tasks),
-                        recordsFiltered=len(sorted_tasks)))
+                        recordsTotal=total_records,
+                        recordsFiltered=records_filtered))  # bug?
 
     @classmethod
     def maybe_normalize_for_sort(cls, tasks, sort_by):

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,13 @@ classes = """
 classifiers = [s.strip() for s in classes.split('\n') if s]
 
 
+EXTRAS_REQUIRE = {
+    "elasticsearch": ["elasticsearch>=5.4,<6.4", "elasticsearch_dsl>=5.4,<6.4", "requests>=2.13,<3", ],
+}
+
+
+EXTRAS_REQUIRE.update({':python_version == "2.7"': ['futures']})
+
 setup(
     name='flower',
     version=get_package_version(),
@@ -54,6 +61,7 @@ setup(
     classifiers=classifiers,
     packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=get_requirements('default.txt'),
+    extras_require=EXTRAS_REQUIRE,
     test_suite="tests",
     tests_require=get_requirements('test.txt'),
     package_data={'flower': ['templates/*', 'static/*.*',
@@ -61,9 +69,11 @@ setup(
     entry_points={
         'console_scripts': [
             'flower = flower.__main__:main',
+            'flower-indexer = flower.__indexer__:main',
         ],
         'celery.commands': [
             'flower = flower.command:FlowerCommand',
+            'flower-indexer = flower.command:IndexerCommand',
         ],
     },
 )


### PR DESCRIPTION
This looks to add elasticsearch as the task event history backend to flower.

# Proposed Solution
This is mainly 2 pieces:

- indexing events into elasticsearch in a somewhat efficient manner (for the process and for elasticsearch)
- searching/sorting/pagination of task history & task lookup by means of elasticsearch.


# Done so far (working)
- indexing tasks into elasticsearch

  - I have a background thread that buffers up task events based on a queue and sends bulk index requests into elasticsearch

- Searching (moderate support for different fields), sorting on all fields. The sorting appears to work but needs more QA. Pagination (works fairly well but I have noticed a bug in some circumstances).

- Dashboard able to pull from elasticsearch (at startup)

# Questions

- where will this logic live? flower subcommand? flower proper (w/ elasticsearch flag settings) @johnarnold 

 - originally I had the indexer outside of flower. It's now in flower, but configured in a hack-off standalone mode, based currently just on `argv`. There are a few `--elasticsearch` flags to control the behavior, just for draft/dev mode for now.
- I am using `kombu`'s `LRUCache` to cache certain `search_after` queries for the task history pagination. It is my way around the elasticsearch pagination restrictions, and keeps deep pagination requests super performant in my testing.

- can we improve the elasticsearch indexing process?