### PR TITLE
Document the GetQueueLengths API endpoint

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -77,3 +77,4 @@ Scott Kruger
 David Schneider
 S M Ahasanul Haque
 Leo Singer
+Pavel Savchenko

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -366,6 +366,36 @@ class GetQueueLengths(BaseTaskHandler):
     @web.authenticated
     @gen.coroutine
     def get(self):
+        """
+Return length of all active queues
+
+**Example request**:
+
+.. sourcecode:: http
+
+  GET /api/queues/length
+  Host: localhost:5555
+
+**Example response**:
+
+.. sourcecode:: http
+
+  HTTP/1.1 200 OK
+  Content-Length: 94
+  Content-Type: application/json; charset=UTF-8
+
+  {
+      "active_queues": [
+          {"name": "celery", "messages": 0},
+          {"name": "video-queue", "messages": 5}
+      ]
+  }
+
+:reqheader Authorization: optional OAuth token to authenticate
+:statuscode 200: no error
+:statuscode 401: unauthorized request
+:statuscode 503: result backend is not configured
+        """
         app = self.application
         broker_options = self.capp.conf.BROKER_TRANSPORT_OPTIONS
 


### PR DESCRIPTION
It's pretty useful and I missed it until I started to dig into the code to copy the broker's tab into a new endpoint 🙄 

By the way it took me a while to figure out how docs work, would it be useful to add this to docs?:
```
pip install -r requirements/docs.txt
cd docs && make html
```