### PR TITLE
Fix docs for default inspect_timeout value

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -174,7 +174,7 @@ The example below shows how to filter arguments and limit display lengths:
 inspect_timeout
 ~~~~~~~~~~~~~~~
 
-Sets worker inspect timeout (by default, `inspect_timeout=10000`
+Sets worker inspect timeout (by default, `inspect_timeout=1000`
 in milliseconds)
 
 .. _keyfile:


### PR DESCRIPTION
The default value for `inspect_timeout` is `1000` not `10000`.

See default value here:
https://github.com/mher/flower/blob/ceb6e1bd8c432f7783ef6345485d1abd6c7f492b/flower/options.py#L20-L21
