### PR TITLE
add back dashboard refresh button

### DIFF
--- a/flower/templates/dashboard.html
+++ b/flower/templates/dashboard.html
@@ -17,6 +17,11 @@
     <div class="panel panel-default">
         <div class="panel-body">
 
+    <div class="btn-toolbar">
+      <div class="btn-group">
+        <a class="btn" href="./?refresh=True">Refresh</a>
+      </div>
+    </div>
     <table id="workers-table" class="table table-bordered table-striped">
       <thead>
         <tr>


### PR DESCRIPTION
Fixes issue mentioned in #856. The refresh functionality is already there and is triggered by adding /?refresh=True to the url, I added a button that points to the current page with the refresh parameter appended to the url. 