### PR TITLE
Fixing GitHub OAuth callback handling

### DIFF
--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -110,7 +110,12 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
         if response.error:
             raise tornado.auth.AuthError(
                 'OAuth authenticator error: %s' % str(response))
-        self.write(json.loads(response.body.decode('utf-8')))
+
+        json_decode = json.loads(response.body.decode('utf-8'))
+
+        logger.debug(json_decode)
+
+        self.write(json_decode)
 
     @tornado.gen.coroutine
     def get(self):
@@ -120,6 +125,13 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
                 redirect_uri=redirect_uri,
                 code=self.get_argument('code'),
             )
+
+            logger = logging.getLogger()
+
+            logger.setLevel(logging.DEBUG)
+
+            logger.debug(user)
+
             yield self._on_auth(user)
         else:
             yield self.authorize_redirect(
@@ -132,6 +144,13 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
 
     @tornado.gen.coroutine
     def _on_auth(self, user):
+
+        logger = logging.getLogger()
+
+        logger.setLevel(logging.DEBUG)
+
+        logger.debug(user)
+
         if not user:
             raise tornado.web.HTTPError(500, 'OAuth authentication failed')
         access_token = user['access_token']

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -82,7 +82,7 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
     _OAUTH_SETTINGS_KEY = 'oauth'
 
     @tornado.gen.coroutine
-    def get_authenticated_user(self, redirect_uri, code, callback):
+    def get_authenticated_user(self, redirect_uri, code):
         body = urlencode({
             "redirect_uri": redirect_uri,
             "code": code,

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -101,7 +101,7 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
             raise tornado.auth.AuthError(
                 'OAuth authenticator error: %s' % str(response))
 
-        raise tornado.gen.Return(response.body.decode('utf-8'))
+        raise tornado.gen.Return(json.loads(response.body.decode('utf-8')))
 
     @tornado.gen.coroutine
     def get(self):
@@ -111,7 +111,6 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
                 redirect_uri=redirect_uri,
                 code=self.get_argument('code'),
             )
-
             yield self._on_auth(user)
         else:
             yield self.authorize_redirect(

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -105,6 +105,7 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
                      'Accept': 'application/json'}, body=body)
 
         logger.debug(response)
+        logger.debug(response.body)
 
         if response.error:
             raise tornado.auth.AuthError(

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -115,7 +115,7 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
 
         logger.debug(json_decode)
 
-        return self.write(json_decode)
+        raise tornado.gen.Return(json_decode)
 
     @tornado.gen.coroutine
     def get(self):

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -115,7 +115,7 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
 
         logger.debug(json_decode)
 
-        self.write(json_decode)
+        return self.write(json_decode)
 
     @tornado.gen.coroutine
     def get(self):

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import json
 import re
+import logging
 
 try:
     from urllib.parse import urlencode
@@ -91,11 +92,19 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
             "grant_type": "authorization_code",
         })
 
+        logger = logging.getLogger()
+
+        logger.setLevel(logging.DEBUG)
+
+        logger.debug(body)
+
         response = yield self.get_auth_http_client().fetch(
             self._OAUTH_ACCESS_TOKEN_URL,
             method="POST",
             headers={'Content-Type': 'application/x-www-form-urlencoded',
                      'Accept': 'application/json'}, body=body)
+
+        logger.debug(response)
 
         if response.error:
             raise tornado.auth.AuthError(

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import json
 import re
-import logging
 
 try:
     from urllib.parse import urlencode
@@ -92,30 +91,17 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
             "grant_type": "authorization_code",
         })
 
-        logger = logging.getLogger()
-
-        logger.setLevel(logging.DEBUG)
-
-        logger.debug(body)
-
         response = yield self.get_auth_http_client().fetch(
             self._OAUTH_ACCESS_TOKEN_URL,
             method="POST",
             headers={'Content-Type': 'application/x-www-form-urlencoded',
                      'Accept': 'application/json'}, body=body)
 
-        logger.debug(response)
-        logger.debug(response.body)
-
         if response.error:
             raise tornado.auth.AuthError(
                 'OAuth authenticator error: %s' % str(response))
 
-        json_decode = json.loads(response.body.decode('utf-8'))
-
-        logger.debug(json_decode)
-
-        raise tornado.gen.Return(json_decode)
+        raise tornado.gen.Return(response.body.decode('utf-8'))
 
     @tornado.gen.coroutine
     def get(self):
@@ -125,12 +111,6 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
                 redirect_uri=redirect_uri,
                 code=self.get_argument('code'),
             )
-
-            logger = logging.getLogger()
-
-            logger.setLevel(logging.DEBUG)
-
-            logger.debug(user)
 
             yield self._on_auth(user)
         else:
@@ -144,13 +124,6 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
 
     @tornado.gen.coroutine
     def _on_auth(self, user):
-
-        logger = logging.getLogger()
-
-        logger.setLevel(logging.DEBUG)
-
-        logger.debug(user)
-
         if not user:
             raise tornado.web.HTTPError(500, 'OAuth authentication failed')
         access_token = user['access_token']


### PR DESCRIPTION
There exists 2 issues:

- With the latest changes to auth.py `get_authenticated_user()` is being called with 3 parameters and no longer 4. This results in a TypeError complaining about a missing positional argument.

- The final `self.write()` line in `get_authenticated_user()` is not returning a Future that can be yielded by the calling coroutine. From Python 3.3 it is safe to use the "return" keyword but I opted for the Python 2.7 safe version and am returning a result by raising the "Return" exception (this is an accepted and valid way of returning values from coroutines in Tornado... which I learnt today)