### PR TITLE
Fix the out-dated doc link in Worker.html

### DIFF
--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -328,7 +328,7 @@
                 {% for name,value in sorted(worker.get('conf', {}).items()) %}
                     {% if value is not None %}
                       <tr>
-                        <td><a href="http://docs.celeryproject.org/en/latest/configuration.html#{{ name.lower().replace('_', '-') }}" target="_blank">{{ name }}</a></td>
+                        <td><a href="http://docs.celeryproject.org/en/latest/userguide/configuration.html#{{ name.lower().replace('_', '-') }}" target="_blank">{{ name }}</a></td>
                         <td>{{ value }}</td>
                       </tr>
                     {% end %}


### PR DESCRIPTION
Currently if we go to any worker page then click "Config" tab, we can click on the item name to go the documentation page. But the doc page structure has changed, and user would go to 404 page.

For example, if I click on `accept_content`, I will be redirected to http://docs.celeryproject.org/en/latest/configuration.html#accept-content which gives warning "This page does not exist yet.". It should be http://docs.celeryproject.org/en/latest/userguide/configuration.html#accept-content instead.

This can be fixed by updating the link in this Worker.html file.