### PR TITLE
Declare futures dependency using environment markers. Fixes #833.

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,3 +2,4 @@ celery>=3.1.0
 tornado>=4.2.0,<6.0.0
 babel>=1.0
 pytz
+futures; python_version=="2.7"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import os
 import re
-import sys
 
 from setuptools import setup, find_packages
 
@@ -44,11 +43,6 @@ classes = """
 classifiers = [s.strip() for s in classes.split('\n') if s]
 
 
-install_requires = get_requirements('default.txt')
-if sys.version_info < (3, 0):
-    install_requires.append('futures')
-
-
 setup(
     name='flower',
     version=get_package_version(),
@@ -60,7 +54,7 @@ setup(
     license='BSD',
     classifiers=classifiers,
     packages=find_packages(exclude=['tests', 'tests.*']),
-    install_requires=install_requires,
+    install_requires=get_requirements('default.txt'),
     test_suite="tests",
     tests_require=get_requirements('test.txt'),
     package_data={'flower': ['templates/*', 'static/*.*',


### PR DESCRIPTION
This PR reflects a cherry-pick of the fix proposed in #834, but against master.  It would be nice to have a release of #834, but in lieu of that, it would be nice to have a release of master with this bugfix.

This PR at least demonstrates for #834 that the tests pass against master.