### PR TITLE
Avoid including apk and pip caches in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:alpine
 
 # Get latest root certificates
-RUN apk add --update ca-certificates && update-ca-certificates
+RUN apk add --no-cache ca-certificates && update-ca-certificates
 
 # Install the required packages
-RUN pip install redis flower
+RUN pip install --no-cache-dir redis flower
 
 # PYTHONUNBUFFERED: Force stdin, stdout and stderr to be totally unbuffered. (equivalent to `python -u`)
 # PYTHONHASHSEED: Enable hash randomization (equivalent to `python -R`)


### PR DESCRIPTION
This prevents the resulting image from including the following unnecessary paths:

* /var/cache/apk
* /root/.cache

(This currently results in a reduction of about ~14 MB.)