### PR TITLE
restrict release dependencies with version upper-bound (#878)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -79,3 +79,4 @@ S M Ahasanul Haque
 Leo Singer
 Pavel Savchenko
 Bhargav Srinivasan
+Josiah Berkebile

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
-celery>=3.1.0
+celery>=3.1.0,<5.0.0
 tornado>=4.2.0,<6.0.0
-babel>=1.0
+babel>=1.0,<8.0.0
 pytz
-futures; python_version=="2.7"
+futures<4.0.0; python_version=="2.7"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,3 @@
 -r default.txt
 -r test.txt
-redis
+redis<4.0.0


### PR DESCRIPTION
There's no Development documentation that I could find, but I ran a `pip install -r dev.txt` and `./tests/run-unit-tests.sh` in a clean Conda environment to make sure everything was passing before opening this PR.  This is a pretty simple change, all I did was look-up the latest versions of the libraries for this current build which we know is functional and set the upper-bound to the next major version for each dependency.