### PR TITLE
Add support for Python 3.7/3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 os:
   - linux
@@ -6,7 +7,12 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8-dev"
   - "pypy"
+matrix:
+  allow_failures:
+    - python: "3.8-dev"
 install:
   - pip install tox-travis
 before_script:

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -81,3 +81,4 @@ Pavel Savchenko
 Bhargav Srinivasan
 Josiah Berkebile
 Deniz Dogan
+Aliaksei Urbanski

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,5 @@
-celery>=3.1.0
+celery>=3.1.0; python_version<"3.7"
+celery>=4.3.0; python_version>="3.7"
 tornado>=4.2.0,<6.0.0
 humanize==0.5.1
 pytz

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ classes = """
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,pypy,pyp3}-{celery3,celery4}
+envlist = {py27,py34,py35,py36,pypy,pyp3}-{celery3,celery4},{py37,py38}-celery4
 skip_missing_interpreters = True
 
 [testenv]
@@ -8,7 +8,7 @@ deps =
     pytest
 setenv =
     celery3: CELERY_VERSION=3.1.25
-    celery4: CELERY_VERSION=4.2.1
+    celery4: CELERY_VERSION=4.3.0
 commands =
     pip install -q Celery=={env:CELERY_VERSION}
     py.test tests/


### PR DESCRIPTION
As a software engineer, I'd like to have support for modern versions of Python declared in `setup.py` and to have corresponding tests on CI.

These changes:
 - Make the requirements compatible with Python 3.7+
 - Add Python 3.7 to `setup.py`
 - Add Python 3.7 and 3.8-dev to `.travis.yml`
 - Add `{py37,py38}-celery4` to the `envlist` at `tox.ini`
 - Bump `CELERY_VERSION` to `4.3.0` for `celery4` at `tox.ini`