### PR TITLE
Added support for more tornado versions depending on python version

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -82,3 +82,4 @@ Bhargav Srinivasan
 Josiah Berkebile
 Deniz Dogan
 Aliaksei Urbanski
+Mike Dearman

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 celery>=3.1.0; python_version<"3.7"
 celery>=4.3.0; python_version>="3.7"
-tornado>=4.2.0,<7.0.0; python_version<"3.5.2"
+tornado>=5.0.0,<6.0.0; python_version<"3.5.2"
 tornado>=5.0.0,<7.0.0; python_version>="3.5.2"
 humanize==0.5.1
 pytz

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,7 @@
 celery>=3.1.0; python_version<"3.7"
 celery>=4.3.0; python_version>="3.7"
-tornado>=4.2.0,<6.0.0
+tornado>=4.2.0,<7.0.0; python_version<"3.5.2"
+tornado>=5.0.0,<7.0.0; python_version>="3.5.2"
 humanize==0.5.1
 pytz
 futures; python_version=="2.7"

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
 setenv =
     celery3: CELERY_VERSION=3.1.25
     celery4: CELERY_VERSION=4.3.0
-    tornado5: TORNADO_VERSION=>=4.2.0,<6.0.0
+    tornado5: TORNADO_VERSION=>=5.0.0,<6.0.0
     tornado6: TORNADO_VERSION=>=6.0.0,<7.0.0
 commands =
     pip install -q Celery=={env:CELERY_VERSION}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,pypy,pyp3}-{celery3,celery4},{py37,py38}-celery4
+envlist = {py27,py34,pypy,pyp3}-{celery3,celery4}-{tornado5},{py35,py36}-{celery3,celery4}-{tornado5,tornado6},{py37,py38}-celery4-{tornado5,tornado6}
 skip_missing_interpreters = True
 
 [testenv]
@@ -9,8 +9,11 @@ deps =
 setenv =
     celery3: CELERY_VERSION=3.1.25
     celery4: CELERY_VERSION=4.3.0
+    tornado5: TORNADO_VERSION=>=4.2.0,<6.0.0
+    tornado6: TORNADO_VERSION=>=6.0.0,<7.0.0
 commands =
     pip install -q Celery=={env:CELERY_VERSION}
+    pip install "tornado{env:TORNADO_VERSION}"
     py.test tests/
 passenv =
-    CELERY_VERSION
+    CELERY_VERSION TORNADO_VERSION


### PR DESCRIPTION
Added support for more tornado versions depending on python version:

- tornado>=4.2.0,<6.0.0; python_version<"3.5.2"
- tornado>=5.0.0,<7.0.0; python_version>="3.5.2"

This allows python 3.5.2+ projects to use the latest tornado (6.0.2 currently) with flower which was disallowed after fixes for issues #878 and #886.

Added tox tests to test combination of python, celery, and tornado versions.

This resolves #903.