### PR TITLE
Default bind on localhost

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -83,3 +83,4 @@ Josiah Berkebile
 Deniz Dogan
 Aliaksei Urbanski
 Mike Dearman
+George Thessalonikefs

--- a/flower/command.py
+++ b/flower/command.py
@@ -133,7 +133,7 @@ class FlowerCommand(Command):
         if not options.unix_socket:
             logger.info(
                 "Visit me at http%s://%s:%s", 's' if ssl else '',
-                options.address or 'localhost', options.port
+                options.address or '0.0.0.0', options.port
             )
         else:
             logger.info("Visit me via unix socket file: %s" % options.unix_socket)

--- a/flower/options.py
+++ b/flower/options.py
@@ -11,7 +11,7 @@ DEFAULT_CONFIG_FILE = 'flowerconfig.py'
 
 define("port", default=5555,
        help="run on the given port", type=int)
-define("address", default='',
+define("address", default='localhost',
        help="run on the given address", type=str)
 define("unix_socket", default='',
        help="path to unix socket to bind", type=str)


### PR DESCRIPTION
The documentation hints that flower binds to localhost by default.
Currently the address option defaults to the empty string. This option is passed to tornado which in turn will handle it as a signal to bind to all interfaces.
From https://github.com/tornadoweb/tornado/blob/master/tornado/netutil.py
>def bind_sockets(
>...
>Address may be an empty string or None to listen on all available interfaces...

This PR addresses the issue by specifically using 'localhost' as the default value.