### PR TITLE
Fix task time limits setting from dashboard

### DIFF
--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -250,20 +250,21 @@ var flower = (function () {
         event.preventDefault();
         event.stopPropagation();
 
-        var workername = $('#workername').text(),
+        var post_data = {
+                'workername': $('#workername').text()
+            },
             taskname = $(event.target).closest("tr").children("td:eq(0)").text(),
+            type = $(event.target).text().toLowerCase(),
             timeout = $(event.target).siblings().closest("input").val();
 
         taskname = taskname.split(' ')[0]; // removes [rate_limit=xxx]
+        post_data[type] = timeout;
 
         $.ajax({
             type: 'POST',
             url: url_prefix() + '/api/task/timeout/' + taskname,
             dataType: 'json',
-            data: {
-                'workername': workername,
-                'type': timeout,
-            },
+            data: post_data,
             success: function (data) {
                 show_success_alert(data.message);
             },


### PR DESCRIPTION
Send limit type as parameter name in POST-request ('soft' or 'hard'), not literally 'type'.

Closes #919