### PR TITLE
Fix/bug in google oauth2

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -83,3 +83,4 @@ Josiah Berkebile
 Deniz Dogan
 Aliaksei Urbanski
 Mike Dearman
+Francisco J. Capdevila

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -63,7 +63,7 @@ class GoogleAuth2LoginHandler(BaseHandler, tornado.auth.GoogleOAuth2Mixin):
         self.set_secure_cookie("user", str(email))
 
         next_ = self.get_argument('next', self.application.options.url_prefix or '/')
-        if self.application.options.url_prefix and next[0] != '/':
+        if self.application.options.url_prefix and next_[0] != '/':
             next_ = '/' + next_
 
         self.redirect(next_)


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/mnt/packages/anaconda3/envs/venv/lib/python3.6/site-packages/tornado/web.py", line 1699, in _execute
    result = await result
  File "/mnt/packages/anaconda3/envs/venv/lib/python3.6/site-packages/tornado/gen.py", line 742, in run
    yielded = self.gen.throw(*exc_info)  # type: ignore
  File "/mnt/packages/anaconda3/envs/venv/lib/python3.6/site-packages/flower/views/auth.py", line 32, in get
    yield self._on_auth(user)
  File "/mnt/packages/anaconda3/envs/venv/lib/python3.6/site-packages/tornado/gen.py", line 735, in run
    value = future.result()
  File "/mnt/packages/anaconda3/envs/venv/lib/python3.6/site-packages/tornado/gen.py", line 748, in run
    yielded = self.gen.send(value)
  File "/mnt/packages/anaconda3/envs/venv/lib/python3.6/site-packages/flower/views/auth.py", line 66, in _on_auth
    if self.application.options.url_prefix and next[0] != '/':
TypeError: 'builtin_function_or_method' object is not subscriptable
```