### PR TITLE
Add ability to dump and restore state counter from persistent database (shelve)

### DIFF
--- a/flower/events.py
+++ b/flower/events.py
@@ -34,8 +34,9 @@ class EventsState(State):
     # EventsState object is created and accessed only from ioloop thread
 
     def __init__(self, *args, **kwargs):
+        args, extra_args = args[:10], args[10:]
+        self.counter = extra_args[0] if extra_args else collections.defaultdict(Counter)
         super(EventsState, self).__init__(*args, **kwargs)
-        self.counter = collections.defaultdict(Counter)
 
     def event(self, event):
         worker_name = event['hostname']
@@ -51,6 +52,10 @@ class EventsState(State):
 
         # Save the event
         super(EventsState, self).event(event)
+
+    def __reduce__(self):
+        classobj, args = super(EventsState, self).__reduce__()
+        return classobj, args + (self.counter, )
 
 
 class Events(threading.Thread):


### PR DESCRIPTION
When use `persistent=True` to dump state to the file, counter data is not dumped.

Therefore after restoring from the file, on dashboard we do not see any statistics, everything is 0.

To add ability to store counter along with the state, `__reduce__` method was overridden and `__init__` to accept counter.

Note: we can try to restore from `kwargs` but for these we need to create `__new__` constructor for EventState class and add additional magic method (as shelve is using protocol 3 by default)