### PR TITLE
Add basic support for redis with ssl on the broker page

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -85,3 +85,4 @@ Aliaksei Urbanski
 Mike Dearman
 Francisco J. Capdevila
 Scott Allen
+Johan Adami

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -401,8 +401,12 @@ Return length of all active queues
         if app.transport == 'amqp' and app.options.broker_api:
             http_api = app.options.broker_api
 
+        broker_use_ssl = None
+        if self.capp.conf.BROKER_USE_SSL:
+            broker_use_ssl = self.capp.conf.BROKER_USE_SSL
+
         broker = Broker(app.capp.connection().as_uri(include_password=True),
-                        http_api=http_api, broker_options=broker_options)
+                        http_api=http_api, broker_options=broker_options, broker_use_ssl=broker_use_ssl)
 
         queue_names = ControlHandler.get_active_queue_names()
 

--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -182,13 +182,13 @@ class RedisSsl(Redis):
     def __init__(self, broker_url, *args, **kwargs):
         if 'broker_use_ssl' not in kwargs:
             raise ValueError('rediss broker requires broker_use_ssl')
-        self.ssl_cert_reqs = kwargs['broker_use_ssl']['ssl_cert_reqs']
+        self.broker_use_ssl = kwargs.get('broker_use_ssl', {})
         super(RedisSsl, self).__init__(broker_url, *args, **kwargs)
 
     def _get_redis_client_args(self):
         client_args = super(RedisSsl, self)._get_redis_client_args()
         client_args['ssl'] = True
-        client_args['ssl_cert_reqs'] = self.ssl_cert_reqs
+        client_args.update(self.broker_use_ssl)
         return client_args
 
 

--- a/flower/views/broker.py
+++ b/flower/views/broker.py
@@ -24,9 +24,13 @@ class BrokerView(BaseHandler):
         if app.transport == 'amqp' and app.options.broker_api:
             http_api = app.options.broker_api
 
+        broker_use_ssl = None
+        if self.capp.conf.BROKER_USE_SSL:
+            broker_use_ssl = self.capp.conf.BROKER_USE_SSL
+
         try:
             broker = Broker(app.capp.connection().as_uri(include_password=True),
-                            http_api=http_api, broker_options=broker_options)
+                            http_api=http_api, broker_options=broker_options, broker_use_ssl=broker_use_ssl)
         except NotImplementedError:
             raise web.HTTPError(
                 404, "'%s' broker is not supported" % app.transport)

--- a/flower/views/monitor.py
+++ b/flower/views/monitor.py
@@ -92,8 +92,11 @@ class BrokerMonitor(BaseHandler):
         capp = app.capp
 
         try:
+            broker_use_ssl = None
+            if self.capp.conf.BROKER_USE_SSL:
+                broker_use_ssl = self.capp.conf.BROKER_USE_SSL
             broker = Broker(capp.connection().as_uri(include_password=True),
-                            http_api=app.options.broker_api)
+                            http_api=app.options.broker_api, broker_use_ssl=broker_use_ssl)
         except NotImplementedError:
             self.write({})
             return

--- a/tests/unit/utils/test_broker.py
+++ b/tests/unit/utils/test_broker.py
@@ -57,7 +57,6 @@ class TestRedis(unittest.TestCase):
             b = Broker('redis://localhost:6379/0', broker_options=options)
             self.assertEqual(expected, b.priority_steps)
 
-
     def test_url(self):
         b = Broker('redis://foo:7777/9')
         self.assertEqual('foo', b.host)
@@ -78,6 +77,28 @@ class TestRedis(unittest.TestCase):
         self.assertEqual(4444, b.port)
         self.assertEqual(5, b.vhost)
         self.assertEqual('pass', b.password)
+
+
+class TestRedisSsl(unittest.TestCase):
+
+    BROKER_OPTIONS_WITH_SSL = {'broker_use_ssl': {'ssl_cert_reqs': 0}}
+
+    def test_init_with_broker_use_ssl(self):
+        b = Broker('rediss://localhost:6379/0', **self.BROKER_OPTIONS_WITH_SSL)
+        self.assertFalse(isinstance(b, RabbitMQ))
+        self.assertTrue(isinstance(b, Redis))
+
+    def test_init_without_broker_use_ssl(self):
+        with self.assertRaises(ValueError):
+            Broker('rediss://localhost:6379/0')
+
+    def test_redis_client_args(self):
+        b = Broker('rediss://:pass@host:4444/5', **self.BROKER_OPTIONS_WITH_SSL)
+        self.assertEqual('host', b.host)
+        self.assertEqual(4444, b.port)
+        self.assertEqual(5, b.vhost)
+        self.assertEqual('pass', b.password)
+        self.assertEqual(0, b.ssl_cert_reqs)
 
 
 class TestRedisSocket(unittest.TestCase):


### PR DESCRIPTION
Summary:
- Fixes #832 
- This adds ssl support for redis using the [broker_use_ssl](https://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-use-ssl) option that comes directly from the celery app.
- I'm only passing through the `ssl_cert_reqs` argument because that's all I've needed, but it should be easy for anyone to extend this
- The code is slightly refactored to more easily reuse the existing Redis broker class.
- I followed the current pattern of adding the parameters everywhere `Broker` is called.
  - this probably isn't ideal, but I'm not sure how to be less repetitive without a larger refactor of broker instantiation

Test Plan:
- I added several unit tests to ensure the RedisSsl broker instantiates or fails depending on `broker_use_ssl` being available and ran them with `tox`
- I tested it against a redis instance I have available that requires ssl
- I tested it against redis://localhost
- I did not test further URL options like username and password, but those should be unaffected