### PR TITLE
Modify url_prefix function to remove trailing slashes

### DIFF
--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -25,6 +25,7 @@ var flower = (function () {
     function url_prefix() {
         var url_prefix = $('#url_prefix').val();
         if (url_prefix) {
+            url_prefix = url_prefix.replace(/\/+$/, '');
             if (url_prefix.startsWith('/')) {
                 return url_prefix;
             } else {


### PR DESCRIPTION
Related to https://github.com/mher/flower/issues/860

This is a small JS improvement

The function `active_page` expects a `url_prefix` w/o trailing slashes, as described on that issue, otherwise it never returns `true`; because it uses a naive approach to joining URL paths.

This MR simply extends the function `url_prefix` to remove any trailing slashes.