### PR TITLE
Hide the `Logout` button if `basic_auth` was specified

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -86,3 +86,4 @@ Mike Dearman
 Francisco J. Capdevila
 Scott Allen
 Johan Adami
+Ray Marc Marcellones

--- a/flower/templates/base.html
+++ b/flower/templates/base.html
@@ -41,7 +41,7 @@
 
   <body>
     {% block navbar %}
-        {% module Template("navbar.html", active_tab="") %}
+        {% module Template("navbar.html", active_tab="", is_basic_auth=is_basic_auth) %}
     {% end %}
 
     <div class="container-fluid">

--- a/flower/templates/broker.html
+++ b/flower/templates/broker.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="broker") %}
+  {% module Template("navbar.html", active_tab="broker", is_basic_auth=is_basic_auth) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/dashboard.html
+++ b/flower/templates/dashboard.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="dashboard") %}
+  {% module Template("navbar.html", active_tab="dashboard", is_basic_auth=is_basic_auth)%}
 {% end %}
 
 {% block container %}

--- a/flower/templates/monitor.html
+++ b/flower/templates/monitor.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="monitor") %}
+  {% module Template("navbar.html", active_tab="monitor", is_basic_auth=is_basic_auth) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/navbar.html
+++ b/flower/templates/navbar.html
@@ -15,7 +15,9 @@
             <li {% if active_tab == "monitor" %}class="active"{% end %}><a href="{{ reverse_url('monitor') }}">Monitor</a></li>
         </ul>
         <ul class="nav pull-right">
-          <li><a href="{{ reverse_url('logout') }}">Logout</a></li>
+          {% if not is_basic_auth %}
+            <li><a href="{{ reverse_url('logout') }}">Logout</a></li>
+          {% end %}
           <li><a href="https://flower.readthedocs.io" target="_blank">Docs</a></li>
           <li><a href="https://github.com/mher/flower" target="_blank">Code</a></li>
         </ul>

--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="tasks") %}
+  {% module Template("navbar.html", active_tab="tasks", is_basic_auth=is_basic_auth) %}
 {% end %}
 
 {% block container %}

--- a/flower/templates/tasks.html
+++ b/flower/templates/tasks.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-{% module Template("navbar.html", active_tab="tasks") %}
+  {% module Template("navbar.html", active_tab="tasks", is_basic_auth=is_basic_auth) %}
 {% end %}
 
 

--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="workers") %}
+  {% module Template("navbar.html", active_tab="workers", is_basic_auth=is_basic_auth) %}
 {% end %}
 
 {% block container %}

--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -14,10 +14,13 @@ from ..utils import template, bugreport, prepend_url
 
 class BaseHandler(tornado.web.RequestHandler):
     def render(self, *args, **kwargs):
+        app_options = self.application.options
         functions = inspect.getmembers(template, inspect.isfunction)
         assert not set(map(lambda x: x[0], functions)) & set(kwargs.keys())
         kwargs.update(functions)
-        kwargs.update(url_prefix=self.application.options.url_prefix)
+        kwargs.update(
+            url_prefix=app_options.url_prefix,
+            is_basic_auth=True if app_options.basic_auth else False)
         super(BaseHandler, self).render(*args, **kwargs)
 
     def write_error(self, status_code, **kwargs):


### PR DESCRIPTION
As of the moment, there is no proper way to logout a user using Basic Authentication.
Showing a `Logout` button that isn't working will misled the user.
So it would be a good idea to hide it for now.