### PR TITLE
Python 3.5-3.8 support; celery 4.4 support; adjust CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,20 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
-        celery-version: [4.1, 4.2, 4.3]
-        tornado-version: [5.0, 5.1]
+        python-version: [3.5, 3.6, 3.7, 3.8]
+        celery-version: [4.1, 4.2, 4.3, 4.4]
+        tornado-version: [5.0, 5.1, 6.0]
+        exclude:
+          - python-version: 3.7
+            celery-version: 4.1
+          - python-version: 3.7
+            celery-version: 4.2
+          - python-version: 3.8
+            celery-version: 4.1
+          - python-version: 3.8
+            celery-version: 4.2
+          - python-version: 3.8
+            celery-version: 4.3
 
     steps:
     - uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,11 @@ language: python
 os:
   - linux
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8-dev"
-  - "pypy"
-matrix:
-  allow_failures:
-    - python: "3.8-dev"
+  - "3.8"
+  - "pypy3"
 install:
   - pip install tox-travis
 before_script:

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -92,3 +92,4 @@ Waleed Darwish
 Bjorn Stiel
 Fabio Todaro
 Simon Gurcke
+Jason Held

--- a/flower/__init__.py
+++ b/flower/__init__.py
@@ -1,4 +1,2 @@
-from __future__ import absolute_import
-
 VERSION = (1, 0, 1)
 __version__ = '.'.join(map(str, VERSION)) + '-dev'

--- a/flower/__main__.py
+++ b/flower/__main__.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
 from flower.command import FlowerCommand
 from flower.utils import bugreport
 

--- a/flower/api/__init__.py
+++ b/flower/api/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import tornado.websocket
 
 

--- a/flower/api/control.py
+++ b/flower/api/control.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import time
 import logging
 import datetime

--- a/flower/api/events.py
+++ b/flower/api/events.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 
 from ..api import BaseWebSocketHandler

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 import logging
 

--- a/flower/api/workers.py
+++ b/flower/api/workers.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 
 from tornado import web

--- a/flower/app.py
+++ b/flower/app.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 
 from functools import partial

--- a/flower/command.py
+++ b/flower/command.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import sys
 import atexit

--- a/flower/events.py
+++ b/flower/events.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import with_statement
-
 import time
 import shelve
 import logging
@@ -21,10 +18,7 @@ from celery.events.state import State
 
 from . import api
 
-try:
-    from collections import Counter
-except ImportError:
-    from .utils.backports.collections import Counter
+from collections import Counter
 
 from prometheus_client import Counter as PrometheusCounter, Histogram
 

--- a/flower/options.py
+++ b/flower/options.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import types
 
 from tornado.options import define

--- a/flower/urls.py
+++ b/flower/urls.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 
 from tornado.web import StaticFileHandler, url

--- a/flower/utils/__init__.py
+++ b/flower/utils/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import uuid
 import base64
 import os.path

--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 import json
 import socket
@@ -11,11 +9,7 @@ from tornado import gen
 from tornado import httpclient
 
 
-try:
-    from urllib.parse import urlparse, urljoin, quote, unquote
-except ImportError:
-    from urlparse import urlparse, urljoin
-    from urllib import quote, unquote
+from urllib.parse import urlparse, urljoin, quote, unquote
 
 
 try:

--- a/flower/utils/tasks.py
+++ b/flower/utils/tasks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import datetime
 import time
 

--- a/flower/utils/template.py
+++ b/flower/utils/template.py
@@ -1,8 +1,4 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import re
-import sys
 
 from celery import current_app
 from datetime import datetime
@@ -14,12 +10,6 @@ except ImportError:
 
 from humanize import naturaltime
 from pytz import timezone, utc
-
-
-PY2 = sys.version_info[0] == 2
-if not PY2:
-    unicode = str
-string_types = (str, unicode) if PY2 else (str,)
 
 
 KEYWORDS_UP = ('ssl', 'uri', 'url', 'uuid', 'eta')
@@ -47,14 +37,14 @@ def humanize(obj, type=None, length=None):
             obj = naturaltime(delta)
         else:
             obj = format_time(float(obj), tz) if obj else ''
-    elif isinstance(obj, string_types) and not re.match(UUID_REGEX, obj):
+    elif isinstance(obj, str) and not re.match(UUID_REGEX, obj):
         obj = obj.replace('-', ' ').replace('_', ' ')
         obj = re.sub('|'.join(KEYWORDS_UP),
                      lambda m: m.group(0).upper(), obj)
         if obj and obj not in KEYWORDS_DOWN:
             obj = obj[0].upper() + obj[1:]
     elif isinstance(obj, list):
-        if all(isinstance(x, (int, float) + string_types) for x in obj):
+        if all(isinstance(x, (int, float, str)) for x in obj):
             obj = ', '.join(map(str, obj))
     if length is not None and len(obj) > length:
         obj = obj[:length - 4] + ' ...'

--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 import inspect
 import traceback

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -1,15 +1,9 @@
-from __future__ import absolute_import
-
 import json
 import re
 import os
 import uuid
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
-
+from urllib.parse import urlencode
 import tornado.gen
 import tornado.web
 import tornado.auth

--- a/flower/views/broker.py
+++ b/flower/views/broker.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 
 from tornado import web

--- a/flower/views/dashboard.py
+++ b/flower/views/dashboard.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import time
 

--- a/flower/views/error.py
+++ b/flower/views/error.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import tornado.web
 
 from ..views import BaseHandler

--- a/flower/views/monitor.py
+++ b/flower/views/monitor.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from collections import defaultdict
 
 from tornado import web

--- a/flower/views/tasks.py
+++ b/flower/views/tasks.py
@@ -1,13 +1,7 @@
-from __future__ import absolute_import
-
 from functools import total_ordering
 import copy
 import logging
 
-try:
-    from itertools import imap
-except ImportError:
-    imap = map
 
 from tornado import web
 

--- a/flower/views/workers.py
+++ b/flower/views/workers.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 
 from tornado import web

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,5 @@
 celery>=3.1.0; python_version<"3.7"
 celery>=4.3.0; python_version>="3.7"
-tornado>=5.0.0,<6.0.0; python_version<"3.5.2"
 tornado>=5.0.0,<7.0.0; python_version>="3.5.2"
 prometheus_client==0.8.0
 humanize

--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,12 @@ classes = """
     License :: OSI Approved :: BSD License
     Topic :: System :: Distributed Computing
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
-    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,7 +1,4 @@
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
+from urllib.parse import urlencode
 
 import tornado.testing
 from tornado.options import options

--- a/tests/unit/utils/__init__.py
+++ b/tests/unit/utils/__init__.py
@@ -2,10 +2,7 @@ from celery.utils import uuid
 from celery.events import Event
 
 
-try:
-    from HTMLParser import HTMLParser
-except ImportError:
-    from html.parser import HTMLParser
+from html.parser import HTMLParser
 import xml.etree.ElementTree as ET
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,pypy,pyp3}-{celery3,celery4}-{tornado5},{py35,py36}-{celery3,celery4}-{tornado5,tornado6},{py37,py38}-celery4-{tornado5,tornado6}
+envlist = {py35,py36,py37,py38,pypy3}-{celery43,celery44}-{tornado5,tornado6}
 skip_missing_interpreters = True
 
 [testenv]
@@ -7,8 +7,8 @@ deps =
     mock
     pytest
 setenv =
-    celery3: CELERY_VERSION=3.1.25
-    celery4: CELERY_VERSION=4.3.0
+    celery43: CELERY_VERSION=4.3.0
+    celery44: CELERY_VERSION=4.4.0
     tornado5: TORNADO_VERSION=>=5.0.0,<6.0.0
     tornado6: TORNADO_VERSION=>=6.0.0,<7.0.0
 commands =


### PR DESCRIPTION
this looks to support python3.5-3.8 (and include celery 4.4 and tornado 6.0 in the tests).

this is not looking to change code patterns/styles for py3 era only. This is for issue #960 

it's possible that we're not yet ready to make this commitment, but i suggest that any discussion around timing (not the code change itself) be pushed down to the issue level. celery has to support its community (wider than flower), but I don't think (I may be wrong) that flower has to be caught up in that version issue as strongly. we just must make sure that the tests are honest. and for another, why burden ourselves with the possibility of any security issues from py2.7?