### PR TITLE
use brighter red and green for important and success labels

### DIFF
--- a/flower/static/css/bootstrap.css
+++ b/flower/static/css/bootstrap.css
@@ -622,7 +622,7 @@ a.badge:hover {
 }
 .label-important,
 .badge-important {
-  background-color: #b94a48;
+  background-color: #db120d;
 }
 .label-important[href],
 .badge-important[href] {
@@ -638,7 +638,7 @@ a.badge:hover {
 }
 .label-success,
 .badge-success {
-  background-color: #468847;
+  background-color: #2ec730;
 }
 .label-success[href],
 .badge-success[href] {

--- a/flower/static/css/bootstrap.css
+++ b/flower/static/css/bootstrap.css
@@ -622,7 +622,7 @@ a.badge:hover {
 }
 .label-important,
 .badge-important {
-  background-color: #db120d;
+  background-color: #b94a48;
 }
 .label-important[href],
 .badge-important[href] {
@@ -638,7 +638,7 @@ a.badge:hover {
 }
 .label-success,
 .badge-success {
-  background-color: #2ec730;
+  background-color: #468847;
 }
 .label-success[href],
 .badge-success[href] {

--- a/flower/static/css/flower.css
+++ b/flower/static/css/flower.css
@@ -230,6 +230,16 @@
   display: inline-block;
 }
 
+/* Modify the bootstrap defaults to better discern red and green */
+.label-important,
+.badge-important {
+    background-color: #db120d;
+}
+.label-success,
+.badge-success {
+    background-color: #2ec730;
+}
+
 /* Modify bootstrap dropdown menu to have white font colour instead of
  * gray (recall that the background is green) */
 .nav-collapse .nav > li > a,


### PR DESCRIPTION
Our team discovered the existing red/green colors are too muted for those with red/green color blindness to discern. This diff updates those colors to be fairly brighter.
![image](https://user-images.githubusercontent.com/4760722/79003044-c22aaa00-7b1f-11ea-8ed6-25cbb5be714c.png)
![image](https://user-images.githubusercontent.com/4760722/79003064-c951b800-7b1f-11ea-81ca-356130692171.png)
