### PR TITLE
Add OAuth2 login handler for GitLab.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ env
 venv
 *.retry
 .cache/
+.mypy_cache/

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -87,3 +87,5 @@ Francisco J. Capdevila
 Scott Allen
 Johan Adami
 Wen YE
+Fabio Todaro
+Simon Gurcke

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -87,12 +87,14 @@ The client id, secret and redirect uri should be provided using
 `--oauth2_key`, `--oauth2_secret` and `--oauth2_redirect_uri` options or using
 `FLOWER_OAUTH2_KEY`, `FLOWER_OAUTH2_SECRET` and `FLOWER_OAUTH2_REDIRECT_URI`
 environment variables.
-
-`--auth` is a JSON string for granting access only to the specified email pattern or members of specified groups. ::
+A list of allowed GitLab groups can be specified using the
+`--gitlab_auth_allowed_groups` option or the `FLOWER_GITLAB_AUTH_ALLOWED_GROUPS`
+environment variable.
 
     $ export FLOWER_OAUTH2_KEY=7956724aafbf5e1a93ac
     $ export FLOWER_OAUTH2_SECRET=f9155f764b7e466c445931a6e3cc7a42c4ce47be
     $ export FLOWER_OAUTH2_REDIRECT_URI=http://localhost:5555/login
-    $ celery flower --auth_provider=flower.views.auth.GitLabLoginHandler --auth='{"emails": ".*@example\.com", "groups": ["group1", "group2/subgroup"]}'
+    $ export FLOWER_GITLAB_AUTH_ALLOWED_GROUPS=group1,group2/subgroup
+    $ celery flower --auth_provider=flower.views.auth.GitLabLoginHandler --auth=.*@example\.com
 
 .. _GitLab OAuth2 API: https://docs.gitlab.com/ee/api/oauth2.html

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -64,7 +64,7 @@ GitHub OAuth should be activated using `--auth_provider` option.
 The client id, secret and redirect uri should be provided using
 `--oauth2_key`, `--oauth2_secret` and `--oauth2_redirect_uri` options or using
 `FLOWER_OAUTH2_KEY`, `FLOWER_OAUTH2_SECRET` and `FLOWER_OAUTH2_REDIRECT_URI`
-environment variables.: ::
+environment variables. ::
 
     $ export FLOWER_OAUTH2_KEY=7956724aafbf5e1a93ac
     $ export FLOWER_OAUTH2_SECRET=f9155f764b7e466c445931a6e3cc7a42c4ce47be
@@ -72,3 +72,27 @@ environment variables.: ::
     $ celery flower --auth_provider=flower.views.auth.GithubLoginHandler --auth=.*@example\.com
 
 .. _GitHub OAuth API: https://developer.github.com/v3/oauth/
+
+.. _gitlab-oauth:
+
+GitLab OAuth
+------------
+
+Flower also supports GitLab OAuth. Flower should be registered in
+<https://gitlab.com/profile/applications> before getting started.
+See `GitLab OAuth2 API`_ docs for more info.
+
+GitLab OAuth should be activated using `--auth_provider` option.
+The client id, secret and redirect uri should be provided using
+`--oauth2_key`, `--oauth2_secret` and `--oauth2_redirect_uri` options or using
+`FLOWER_OAUTH2_KEY`, `FLOWER_OAUTH2_SECRET` and `FLOWER_OAUTH2_REDIRECT_URI`
+environment variables.
+
+`--auth` is a JSON string for granting access only to the specified email pattern or members of specified groups. ::
+
+    $ export FLOWER_OAUTH2_KEY=7956724aafbf5e1a93ac
+    $ export FLOWER_OAUTH2_SECRET=f9155f764b7e466c445931a6e3cc7a42c4ce47be
+    $ export FLOWER_OAUTH2_REDIRECT_URI=http://localhost:5555/login
+    $ celery flower --auth_provider=flower.views.auth.GitLabLoginHandler --auth='{"emails": ".*@example\.com", "groups": ["group1", "group2/subgroup"]}'
+
+.. _GitLab OAuth2 API: https://docs.gitlab.com/ee/api/oauth2.html

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -62,8 +62,21 @@ Run the http server on a given address
 auth
 ~~~~
 
-Enables Google OpenID authentication. `auth` is a regexp of emails
-to grant access. For more info see :ref:`google-openid`
+Enables authentication.
+
+For Google `auth` is a regexp of emails allowed to access. ::
+
+    $ flower --auth_provider=flower.views.auth.GoogleAuth2LoginHandler --auth=".*@gmail.com"
+
+For GitHub `auth` is a regexp of emails allowed to access. ::
+
+    $ flower --auth_provider=flower.views.auth.GithubLoginHandler --auth=".*@gmail.com"
+
+For GitLab `auth` is a JSON specifying an email regexp and/or a list of groups allowed to access. ::
+
+    $ flower --auth_provider=flower.views.auth.GitLabLoginHandler --auth='{"emails":".*@gmail\\.com", "groups":["group1", "group2/subgroup"]}'
+
+For more info see :ref:`authentication`
 
 .. _auto_refresh:
 
@@ -306,5 +319,6 @@ Sets authentication provider
 
   - Google `flower.views.auth.GoogleAuth2LoginHandler`
   - GitHub `flower.views.auth.GithubLoginHandler`
+  - GitLab `flower.views.auth.GitLabLoginHandler`
 
 See `Authentication` for usage examples

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -62,21 +62,8 @@ Run the http server on a given address
 auth
 ~~~~
 
-Enables authentication.
-
-For Google `auth` is a regexp of emails allowed to access. ::
-
-    $ flower --auth_provider=flower.views.auth.GoogleAuth2LoginHandler --auth=".*@gmail.com"
-
-For GitHub `auth` is a regexp of emails allowed to access. ::
-
-    $ flower --auth_provider=flower.views.auth.GithubLoginHandler --auth=".*@gmail.com"
-
-For GitLab `auth` is a JSON specifying an email regexp and/or a list of groups allowed to access. ::
-
-    $ flower --auth_provider=flower.views.auth.GitLabLoginHandler --auth='{"emails":".*@gmail\\.com", "groups":["group1", "group2/subgroup"]}'
-
-For more info see :ref:`authentication`
+Enables authentication. `auth` is a regexp of emails to grant access.
+For more info see :ref:`authentication`.
 
 .. _auto_refresh:
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -169,6 +169,24 @@ The example below shows how to filter arguments and limit display lengths:
         task.result = humanize(task.result, length=20)
         return task
 
+.. _gitlab_auth_allowed_groups:
+
+gitlab_auth_allowed_groups
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Comma-separated list of group paths (e.g. ``group1,group2/subgroup``) to
+grant access to when using GitLab auth.
+
+.. _gitlab_auth_allowed_groups:
+
+gitlab_auth_min_access_level
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Minimum required access level of a user in a group to be counted as membership
+for GitLab auth. See `Group and project members API`_ for details.
+
+.. _Group and project members API: https://docs.gitlab.com/ee/api/members.html
+
 .. _inspect_timeout:
 
 inspect_timeout

--- a/flower/command.py
+++ b/flower/command.py
@@ -107,6 +107,10 @@ class FlowerCommand(Command):
                 'secret': options.oauth2_secret or os.environ.get('FLOWER_OAUTH2_SECRET'),
                 'redirect_uri': options.oauth2_redirect_uri or os.environ.get('FLOWER_OAUTH2_REDIRECT_URI'),
             }
+            settings['gitlab_auth'] = {
+                'allowed_groups': options.gitlab_auth_allowed_groups or os.environ.get('FLOWER_GITLAB_AUTH_ALLOWED_GROUPS'),
+                'min_access_level': options.gitlab_auth_min_access_level or os.environ.get('FLOWER_GITLAB_MIN_ACCESS_LEVEL'),
+            }
 
         if options.certfile and options.keyfile:
             settings['ssl_options'] = dict(certfile=abs_path(options.certfile),

--- a/flower/options.py
+++ b/flower/options.py
@@ -20,8 +20,6 @@ define("debug", default=False,
 define("inspect_timeout", default=1000, type=float,
        help="inspect timeout (in milliseconds)")
 define("auth", default='', type=str,
-       help="regexp of emails to grant access")
-define("auth", default='', type=str,
        help="Google/GitHub auth: regexp string of emails to grant access, GitLab auth: JSON config")
 define("basic_auth", type=str, default=None, multiple=True,
        help="enable http basic authentication")

--- a/flower/options.py
+++ b/flower/options.py
@@ -21,6 +21,8 @@ define("inspect_timeout", default=1000, type=float,
        help="inspect timeout (in milliseconds)")
 define("auth", default='', type=str,
        help="regexp of emails to grant access")
+define("auth", default='', type=str,
+       help="Google/GitHub auth: regexp string of emails to grant access, GitLab auth: JSON config")
 define("basic_auth", type=str, default=None, multiple=True,
        help="enable http basic authentication")
 define("oauth2_key", type=str, default=None,

--- a/flower/options.py
+++ b/flower/options.py
@@ -20,9 +20,13 @@ define("debug", default=False,
 define("inspect_timeout", default=1000, type=float,
        help="inspect timeout (in milliseconds)")
 define("auth", default='', type=str,
-       help="Google/GitHub auth: regexp string of emails to grant access, GitLab auth: JSON config")
+       help="regexp of emails to grant access")
 define("basic_auth", type=str, default=None, multiple=True,
        help="enable http basic authentication")
+define("gitlab_auth_allowed_groups", type=str, default='',
+       help="comma-separated list of allowed group paths when using GitLab auth")
+define("gitlab_auth_min_access_level", type=str, default='',
+       help="minimum required group access level when using GitLab auth with allowed groups")
 define("oauth2_key", type=str, default=None,
        help="OAuth2 key (requires --auth)")
 define("oauth2_secret", type=str, default=None,

--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -734,7 +734,7 @@ var flower = (function () {
                 url: url_prefix() + '/tasks/datatable'
             },
             order: [
-                [7, "asc"]
+                [7, "desc"]
             ],
             oSearch: {
                 "sSearch": $.urlParam('state') ? 'state:' + $.urlParam('state') : ''

--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -65,15 +65,14 @@ class BaseHandler(tornado.web.RequestHandler):
             except ValueError:
                 raise tornado.web.HTTPError(401)
 
-        # Google OpenID
+        # OAuth2
         if not self.application.options.auth:
             return True
         user = self.get_secure_cookie('user')
         if user:
             if not isinstance(user, str):
                 user = user.decode()
-            if re.search(self.application.options.auth, user):
-                return user
+            return user
         return None
 
     def get_argument(self, name, default=[], strip=True, type=None):

--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -72,7 +72,8 @@ class BaseHandler(tornado.web.RequestHandler):
         if user:
             if not isinstance(user, str):
                 user = user.decode()
-            return user
+            if re.match(self.application.options.auth, user):
+                return user
         return None
 
     def get_argument(self, name, default=[], strip=True, type=None):


### PR DESCRIPTION
Based on #781 and adapted for GitLab.com.
Partly addresses #966 (this PR does not yet support local installations of GitLab).