### PR TITLE
Remove explicit humanize version

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,5 +2,5 @@ celery>=3.1.0; python_version<"3.7"
 celery>=4.3.0; python_version>="3.7"
 tornado>=5.0.0,<6.0.0; python_version<"3.5.2"
 tornado>=5.0.0,<7.0.0; python_version>="3.5.2"
-humanize==0.5.1
+humanize
 pytz


### PR DESCRIPTION
Humanize is now version 2.4.0, the only major change is dropping Python 2 support https://github.com/jmoiron/humanize/releases 