### PR TITLE
Fix redis SSL broker handling

### DIFF
--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -136,6 +136,7 @@ class RedisBase(BrokerBase):
 class Redis(RedisBase):
 
     def __init__(self, broker_url, *args, **kwargs):
+        self.ssl = 'broker_use_ssl' in kwargs
         super(Redis, self).__init__(broker_url, *args, **kwargs)
         self.host = self.host or 'localhost'
         self.port = self.port or 6379
@@ -215,26 +216,6 @@ class RedisSocket(RedisBase):
                                  password=self.password)
 
 
-class RedisSsl(Redis):
-    """
-    Redis SSL class offering connection to the broker over SSL.
-    This does not currently support SSL settings through the url, only through
-    the broker_use_ssl celery configuration.
-    """
-
-    def __init__(self, broker_url, *args, **kwargs):
-        if 'broker_use_ssl' not in kwargs:
-            raise ValueError('rediss broker requires broker_use_ssl')
-        self.broker_use_ssl = kwargs.get('broker_use_ssl', {})
-        super(RedisSsl, self).__init__(broker_url, *args, **kwargs)
-
-    def _get_redis_client_args(self):
-        client_args = super(RedisSsl, self)._get_redis_client_args()
-        client_args['ssl'] = True
-        client_args.update(self.broker_use_ssl)
-        return client_args
-
-
 class Broker(object):
     def __new__(cls, broker_url, *args, **kwargs):
         scheme = urlparse(broker_url).scheme
@@ -242,8 +223,6 @@ class Broker(object):
             return RabbitMQ(broker_url, *args, **kwargs)
         elif scheme == 'redis':
             return Redis(broker_url, *args, **kwargs)
-        elif scheme == 'rediss':
-            return RedisSsl(broker_url, *args, **kwargs)
         elif scheme == 'redis+socket':
             return RedisSocket(broker_url, *args, **kwargs)
         elif scheme == 'sentinel':

--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -216,7 +216,7 @@ class RedisSocket(RedisBase):
         self.redis = redis.Redis(unix_socket_path='/' + self.vhost,
                                  password=self.password)
 
-        
+
 class RedisSsl(Redis):
     """
     Redis SSL class offering connection to the broker over SSL.
@@ -234,7 +234,7 @@ class RedisSsl(Redis):
         client_args = super(RedisSsl, self)._get_redis_client_args()
         client_args['ssl'] = True
         client_args.update(self.broker_use_ssl)
-        return client_args 
+        return client_args
 
 
 class Broker(object):
@@ -245,7 +245,7 @@ class Broker(object):
         elif scheme == 'redis':
             return Redis(broker_url, *args, **kwargs)
         elif scheme == 'rediss':
-            return RedisSsl(broker_url, *args, **kwargs) 
+            return RedisSsl(broker_url, *args, **kwargs)
         elif scheme == 'redis+socket':
             return RedisSocket(broker_url, *args, **kwargs)
         elif scheme == 'sentinel':

--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -216,6 +216,26 @@ class RedisSocket(RedisBase):
         self.redis = redis.Redis(unix_socket_path='/' + self.vhost,
                                  password=self.password)
 
+        
+class RedisSsl(Redis):
+    """
+    Redis SSL class offering connection to the broker over SSL.
+    This does not currently support SSL settings through the url, only through
+    the broker_use_ssl celery configuration.
+    """
+
+    def __init__(self, broker_url, *args, **kwargs):
+        if 'broker_use_ssl' not in kwargs:
+            raise ValueError('rediss broker requires broker_use_ssl')
+        self.broker_use_ssl = kwargs.get('broker_use_ssl', {})
+        super(RedisSsl, self).__init__(broker_url, *args, **kwargs)
+
+    def _get_redis_client_args(self):
+        client_args = super(RedisSsl, self)._get_redis_client_args()
+        client_args['ssl'] = True
+        client_args.update(self.broker_use_ssl)
+        return client_args 
+
 
 class Broker(object):
     def __new__(cls, broker_url, *args, **kwargs):
@@ -224,6 +244,8 @@ class Broker(object):
             return RabbitMQ(broker_url, *args, **kwargs)
         elif scheme == 'redis':
             return Redis(broker_url, *args, **kwargs)
+        elif scheme == 'rediss':
+            return RedisSsl(broker_url, *args, **kwargs) 
         elif scheme == 'redis+socket':
             return RedisSocket(broker_url, *args, **kwargs)
         elif scheme == 'sentinel':

--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -159,7 +159,8 @@ class Redis(RedisBase):
         return vhost
 
     def _get_redis_client_args(self):
-        return {'host': self.host, 'port': self.port, 'db': self.vhost, 'password': self.password}
+        return {'host': self.host, 'port': self.port, 'db': self.vhost, 'password': self.password,
+                'ssl': self.ssl}
 
     def _get_redis_client(self):
         return redis.Redis(**self._get_redis_client_args())


### PR DESCRIPTION
When the `BrokerView` instantiates a [Broker instance](https://github.com/mher/flower/blob/master/flower/views/broker.py#L32), the URI is passed in using kombu's `as_uri` method. `as_uri` will convert a redis connection string from `rediss://localhost:6379/0` to `redis://localhost:6379/0` (removing the second 's'). This results in the scheme check to never hit the `scheme == 'rediss'` case. If a redis SSL broker is used, this results in hanging requests to the /broker webpage.

This update should fix the issue by using the `broker_use_ssl` kwarg to determine if the redis broker is using ssl, in addition to the `rediss` scheme.