### PR TITLE
Resolve refresh URL when behind proxy with prefix

### DIFF
--- a/flower/templates/dashboard.html
+++ b/flower/templates/dashboard.html
@@ -19,7 +19,7 @@
 
     <div class="btn-toolbar">
       <div class="btn-group">
-        <a class="btn" href="./?refresh=True">Refresh</a>
+        <a class="btn" href="{{ reverse_url('main') }}?refresh=True">Refresh</a>
       </div>
     </div>
     <table id="workers-table" class="table table-bordered table-striped">


### PR DESCRIPTION
When serving flower behind a proxy with a prefix, the refresh URL is
broken.

The URL is constructed using the resolved root URL which adds the prefix if one is configured.