### PR TITLE
Added CORS support

### DIFF
--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -17,6 +17,15 @@ logger = logging.getLogger(__name__)
 
 
 class BaseHandler(tornado.web.RequestHandler):
+    def set_default_headers(self):
+        self.set_header("Access-Control-Allow-Origin", "*")
+        self.set_header("Access-Control-Allow-Headers", "x-requested-with")
+        self.set_header('Access-Control-Allow-Methods', ' PUT, DELETE, OPTIONS')
+
+    def options(self):
+        self.set_status(204)
+        self.finish()
+        
     def render(self, *args, **kwargs):
         app_options = self.application.options
         functions = inspect.getmembers(template, inspect.isfunction)


### PR DESCRIPTION
Adding support for CORS, an issue described in #429 , and solved for older versions in #433 .
The module tornado-cors in #433 is outdated and does not support tornado>=5.11, this solution does not depend on additional dependencies by only adding the needed headers for CORS to BaseHandler.

Let me know if there's any more required changes on this!