### PR TITLE
Add offset option for /api/tasks

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -93,3 +93,4 @@ Bjorn Stiel
 Fabio Todaro
 Simon Gurcke
 Jason Held
+Lukas Matta

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -502,6 +502,7 @@ List tasks
   }
 
 :query limit: maximum number of tasks
+:query offset: skip first n tasks
 :query workername: filter task by workername
 :query taskname: filter tasks by taskname
 :query state: filter tasks by state
@@ -513,6 +514,7 @@ List tasks
         """
         app = self.application
         limit = self.get_argument('limit', None)
+        offset = self.get_argument('offset', None)
         worker = self.get_argument('workername', None)
         type = self.get_argument('taskname', None)
         state = self.get_argument('state', None)
@@ -520,13 +522,14 @@ List tasks
         received_end = self.get_argument('received_end', None)
 
         limit = limit and int(limit)
+        offset = offset and int(offset)
         worker = worker if worker != 'All' else None
         type = type if type != 'All' else None
         state = state if state != 'All' else None
 
         result = []
         for task_id, task in tasks.iter_tasks(
-                app.events, limit=limit, type=type,
+                app.events, limit=limit, offset=offset, type=type,
                 worker=worker, state=state,
                 received_start=received_start,
                 received_end=received_end):

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -18,6 +18,7 @@ from ..utils import tasks
 from ..views import BaseHandler
 from ..utils.broker import Broker
 from ..api.control import ControlHandler
+from collections import OrderedDict
 
 
 logger = logging.getLogger(__name__)
@@ -503,6 +504,7 @@ List tasks
 
 :query limit: maximum number of tasks
 :query offset: skip first n tasks
+:query sort_by: sort tasks by attribute (name, state, received, started)
 :query workername: filter task by workername
 :query taskname: filter tasks by taskname
 :query state: filter tasks by state
@@ -539,7 +541,7 @@ List tasks
             if worker is not None:
               task['worker'] = worker.hostname
             result.append((task_id, task))
-        self.write(dict(result))
+        self.write(OrderedDict(result))
 
 
 class ListTaskTypes(BaseTaskHandler):

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -522,7 +522,7 @@ List tasks
         received_end = self.get_argument('received_end', None)
 
         limit = limit and int(limit)
-        offset = offset and int(offset)
+        offset = offset and max(0, int(offset))
         worker = worker if worker != 'All' else None
         type = type if type != 'All' else None
         state = state if state != 'All' else None

--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -520,6 +520,7 @@ List tasks
         state = self.get_argument('state', None)
         received_start = self.get_argument('received_start', None)
         received_end = self.get_argument('received_end', None)
+        sort_by = self.get_argument('sort_by', None)
 
         limit = limit and int(limit)
         offset = offset and max(0, int(offset))
@@ -529,7 +530,7 @@ List tasks
 
         result = []
         for task_id, task in tasks.iter_tasks(
-                app.events, limit=limit, offset=offset, type=type,
+                app.events, limit=limit, offset=offset, sort_by=sort_by, type=type,
                 worker=worker, state=state,
                 received_start=received_start,
                 received_end=received_end):

--- a/flower/utils/tasks.py
+++ b/flower/utils/tasks.py
@@ -6,7 +6,7 @@ from .search import satisfies_search_terms, parse_search_terms
 from celery.events.state import Task
 
 
-def iter_tasks(events, limit=None, type=None, worker=None, state=None,
+def iter_tasks(events, limit=None, offset=0, type=None, worker=None, state=None,
                sort_by=None, received_start=None, received_end=None,
                started_start=None, started_end=None, search=None):
     i = 0
@@ -40,10 +40,12 @@ def iter_tasks(events, limit=None, type=None, worker=None, state=None,
             continue
         if not satisfies_search_terms(task, search_terms):
             continue
-        yield uuid, task
+        if i >= offset:
+            yield uuid, task
         i += 1
-        if i == limit:
-            break
+        if limit != None:
+            if i == limit + offset:
+                break
 
 
 sort_keys = {'name': str, 'state': str, 'received': float, 'started': float}

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -122,14 +122,18 @@ class TaskTests(AsyncHTTPTestCase):
                                         id='789')
         events += task_succeeded_events(worker='worker1', name='task4',
                                         id='666')
+                                        
+        # for i, e in enumerate(sorted(events, key=lambda event: event['uuid'])):
+        
         for i, e in enumerate(events):
             e['clock'] = i
             e['local_received'] = time.time()
             state.event(e)
         self.app.events.state = state
+        print(self.app.events.state.tasks)
 
         # Test limit 4 and offset 0
-        params = dict(limit=4, offset=0)
+        params = dict(limit=4, offset=0, sort_by='name')
 
         r = self.get('/api/tasks?' + '&'.join(
                         map(lambda x: '%s=%s' % x, params.items())))
@@ -139,11 +143,11 @@ class TaskTests(AsyncHTTPTestCase):
         self.assertEqual(4, len(table))
         firstFetchedTaskName = table[list(table)[0]]['name']
         lastFetchedTaskName =  table[list(table)[-1]]['name']
-        self.assertEqual("task4", firstFetchedTaskName)
-        self.assertEqual("task1", lastFetchedTaskName)
+        self.assertEqual("task1", firstFetchedTaskName)
+        self.assertEqual("task4", lastFetchedTaskName)
 
         # Test limit 4 and offset 1
-        params = dict(limit=4, offset=1)
+        params = dict(limit=4, offset=1, sort_by='name')
 
         r = self.get('/api/tasks?' + '&'.join(
                         map(lambda x: '%s=%s' % x, params.items())))
@@ -153,11 +157,11 @@ class TaskTests(AsyncHTTPTestCase):
         self.assertEqual(3, len(table))
         firstFetchedTaskName = table[list(table)[0]]['name']
         lastFetchedTaskName =  table[list(table)[-1]]['name']
-        self.assertEqual("task3", firstFetchedTaskName)
-        self.assertEqual("task1", lastFetchedTaskName)
+        self.assertEqual("task2", firstFetchedTaskName)
+        self.assertEqual("task4", lastFetchedTaskName)
 
         # Test limit 4 and offset -1 (-1 should act as 0)
-        params = dict(limit=4, offset=-1)
+        params = dict(limit=4, offset=-1, sort_by="name")
 
         r = self.get('/api/tasks?' + '&'.join(
                         map(lambda x: '%s=%s' % x, params.items())))
@@ -167,11 +171,11 @@ class TaskTests(AsyncHTTPTestCase):
         self.assertEqual(4, len(table))
         firstFetchedTaskName = table[list(table)[0]]['name']
         lastFetchedTaskName =  table[list(table)[-1]]['name']
-        self.assertEqual("task4", firstFetchedTaskName)
-        self.assertEqual("task1", lastFetchedTaskName)
+        self.assertEqual("task1", firstFetchedTaskName)
+        self.assertEqual("task4", lastFetchedTaskName)
 
         # Test limit 2 and offset 1
-        params = dict(limit=2, offset=1)
+        params = dict(limit=2, offset=1, sort_by='name')
 
         r = self.get('/api/tasks?' + '&'.join(
                         map(lambda x: '%s=%s' % x, params.items())))
@@ -181,6 +185,6 @@ class TaskTests(AsyncHTTPTestCase):
         self.assertEqual(2, len(table))
         firstFetchedTaskName = table[list(table)[0]]['name']
         lastFetchedTaskName =  table[list(table)[-1]]['name']
-        self.assertEqual("task3", firstFetchedTaskName)
-        self.assertEqual("task2", lastFetchedTaskName)
+        self.assertEqual("task2", firstFetchedTaskName)
+        self.assertEqual("task3", lastFetchedTaskName)
 

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -5,6 +5,12 @@ from celery.result import AsyncResult
 import celery.states as states
 
 from tests.unit import AsyncHTTPTestCase
+from flower.events import EventsState
+from celery.events import Event
+
+from tests.unit.utils import task_succeeded_events
+import json
+import time
 
 
 class ApplyTests(AsyncHTTPTestCase):
@@ -93,7 +99,88 @@ class MockTasks:
 
 
 class TaskTests(AsyncHTTPTestCase):
+    def setUp(self):
+        self.app = super(TaskTests, self).get_app()
+        super(TaskTests, self).setUp()
+
+    def get_app(self):
+        return self.app
 
     @patch('flower.api.tasks.tasks', new=MockTasks)
     def test_task_info(self):
         self.get('/api/task/info/123')
+
+    def test_tasks_pagination(self):
+        state = EventsState()
+        state.get_or_create_worker('worker1')
+        events = [Event('worker-online', hostname='worker1')]
+        events += task_succeeded_events(worker='worker1', name='task1',
+                                        id='123')
+        events += task_succeeded_events(worker='worker1', name='task2',
+                                        id='456')
+        events += task_succeeded_events(worker='worker1', name='task3',
+                                        id='789')
+        events += task_succeeded_events(worker='worker1', name='task4',
+                                        id='666')
+        for i, e in enumerate(events):
+            e['clock'] = i
+            e['local_received'] = time.time()
+            state.event(e)
+        self.app.events.state = state
+
+        # Test limit 4 and offset 0
+        params = dict(limit=4, offset=0)
+
+        r = self.get('/api/tasks?' + '&'.join(
+                        map(lambda x: '%s=%s' % x, params.items())))
+
+        table = json.loads(r.body.decode("utf-8"))
+        self.assertEqual(200, r.code)
+        self.assertEqual(4, len(table))
+        firstFetchedTaskName = table[list(table)[0]]['name']
+        lastFetchedTaskName =  table[list(table)[-1]]['name']
+        self.assertEqual("task4", firstFetchedTaskName)
+        self.assertEqual("task1", lastFetchedTaskName)
+
+        # Test limit 4 and offset 1
+        params = dict(limit=4, offset=1)
+
+        r = self.get('/api/tasks?' + '&'.join(
+                        map(lambda x: '%s=%s' % x, params.items())))
+
+        table = json.loads(r.body.decode("utf-8"))
+        self.assertEqual(200, r.code)
+        self.assertEqual(3, len(table))
+        firstFetchedTaskName = table[list(table)[0]]['name']
+        lastFetchedTaskName =  table[list(table)[-1]]['name']
+        self.assertEqual("task3", firstFetchedTaskName)
+        self.assertEqual("task1", lastFetchedTaskName)
+
+        # Test limit 4 and offset -1 (-1 should act as 0)
+        params = dict(limit=4, offset=-1)
+
+        r = self.get('/api/tasks?' + '&'.join(
+                        map(lambda x: '%s=%s' % x, params.items())))
+
+        table = json.loads(r.body.decode("utf-8"))
+        self.assertEqual(200, r.code)
+        self.assertEqual(4, len(table))
+        firstFetchedTaskName = table[list(table)[0]]['name']
+        lastFetchedTaskName =  table[list(table)[-1]]['name']
+        self.assertEqual("task4", firstFetchedTaskName)
+        self.assertEqual("task1", lastFetchedTaskName)
+
+        # Test limit 2 and offset 1
+        params = dict(limit=2, offset=1)
+
+        r = self.get('/api/tasks?' + '&'.join(
+                        map(lambda x: '%s=%s' % x, params.items())))
+
+        table = json.loads(r.body.decode("utf-8"))
+        self.assertEqual(200, r.code)
+        self.assertEqual(2, len(table))
+        firstFetchedTaskName = table[list(table)[0]]['name']
+        lastFetchedTaskName =  table[list(table)[-1]]['name']
+        self.assertEqual("task3", firstFetchedTaskName)
+        self.assertEqual("task2", lastFetchedTaskName)
+

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -11,6 +11,7 @@ from celery.events import Event
 from tests.unit.utils import task_succeeded_events
 import json
 import time
+from collections import OrderedDict
 
 
 class ApplyTests(AsyncHTTPTestCase):
@@ -130,7 +131,6 @@ class TaskTests(AsyncHTTPTestCase):
             e['local_received'] = time.time()
             state.event(e)
         self.app.events.state = state
-        print(self.app.events.state.tasks)
 
         # Test limit 4 and offset 0
         params = dict(limit=4, offset=0, sort_by='name')
@@ -138,7 +138,8 @@ class TaskTests(AsyncHTTPTestCase):
         r = self.get('/api/tasks?' + '&'.join(
                         map(lambda x: '%s=%s' % x, params.items())))
 
-        table = json.loads(r.body.decode("utf-8"))
+        table = json.loads(r.body.decode("utf-8"), object_pairs_hook=OrderedDict)
+
         self.assertEqual(200, r.code)
         self.assertEqual(4, len(table))
         firstFetchedTaskName = table[list(table)[0]]['name']
@@ -152,7 +153,8 @@ class TaskTests(AsyncHTTPTestCase):
         r = self.get('/api/tasks?' + '&'.join(
                         map(lambda x: '%s=%s' % x, params.items())))
 
-        table = json.loads(r.body.decode("utf-8"))
+        table = json.loads(r.body.decode("utf-8"), object_pairs_hook=OrderedDict)
+
         self.assertEqual(200, r.code)
         self.assertEqual(3, len(table))
         firstFetchedTaskName = table[list(table)[0]]['name']
@@ -166,7 +168,8 @@ class TaskTests(AsyncHTTPTestCase):
         r = self.get('/api/tasks?' + '&'.join(
                         map(lambda x: '%s=%s' % x, params.items())))
 
-        table = json.loads(r.body.decode("utf-8"))
+        table = json.loads(r.body.decode("utf-8"), object_pairs_hook=OrderedDict)
+
         self.assertEqual(200, r.code)
         self.assertEqual(4, len(table))
         firstFetchedTaskName = table[list(table)[0]]['name']
@@ -180,7 +183,8 @@ class TaskTests(AsyncHTTPTestCase):
         r = self.get('/api/tasks?' + '&'.join(
                         map(lambda x: '%s=%s' % x, params.items())))
 
-        table = json.loads(r.body.decode("utf-8"))
+        table = json.loads(r.body.decode("utf-8"), object_pairs_hook=OrderedDict)
+
         self.assertEqual(200, r.code)
         self.assertEqual(2, len(table))
         firstFetchedTaskName = table[list(table)[0]]['name']


### PR DESCRIPTION
When using endpoint ```/api/tasks``` one may need to skip first *n* tasks, e.g. when using pagination. This pull request adds option to skip first *n* tasks by using query param *offset=n* while requesting tasks.

Resolves #989