### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/flower/urls.py
+++ b/flower/urls.py
@@ -68,6 +68,7 @@ handlers = [
     (r"/api/task/events/task-custom/(.*)", events.TaskCustom),
     # Metrics
     (r"/metrics", monitor.Metrics),
+    (r"/healthcheck", monitor.Healthcheck),
     # Static
     (r"/static/(.*)", StaticFileHandler,
      {"path": settings['static_path']}),

--- a/flower/views/monitor.py
+++ b/flower/views/monitor.py
@@ -11,3 +11,9 @@ class Metrics(BaseHandler):
     @gen.coroutine
     def get(self):
         self.write(prometheus_client.generate_latest())
+
+
+class Healthcheck(BaseHandler):
+    @gen.coroutine
+    def get(self):
+        self.write("OK")

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,6 @@
 celery>=3.1.0; python_version<"3.7"
 celery>=4.3.0; python_version>="3.7"
+vine==1.3.0
 tornado>=5.0.0,<7.0.0; python_version>="3.5.2"
 prometheus_client==0.8.0
 humanize

--- a/tests/unit/views/test_monitor.py
+++ b/tests/unit/views/test_monitor.py
@@ -32,3 +32,16 @@ class PrometheusTests(AsyncHTTPTestCase):
         self.assertTrue('task-received' in events)
         self.assertTrue('task-started' in events)
         self.assertTrue('task-succeeded' in events)
+
+
+class HealthcheckTests(AsyncHTTPTestCase):
+    def setUp(self):
+        self.app = super(HealthcheckTests, self).get_app()
+        super(HealthcheckTests, self).setUp()
+
+    def get_app(self):
+        return self.app
+
+    def test_healthcheck_route(self):
+        response = self.get('/healthcheck').body.decode('utf-8')
+        self.assertEquals(response, 'OK')


### PR DESCRIPTION
### Rationale

When running Flower with auth enabled using some orchestration service it's useful to have `healthcheck` endpoint which indicates status of the application without authN required.

### Examples
a)
AWS healthcheck for target group

![Screen Shot 2020-07-25 at 7 16 20 PM](https://user-images.githubusercontent.com/3602533/88461351-57716480-ceab-11ea-981b-f3b4805c7cf1.png)
![Screen Shot 2020-07-25 at 7 17 37 PM](https://user-images.githubusercontent.com/3602533/88461372-84be1280-ceab-11ea-926f-523041480a35.png)

b)
[docker-compose healthcheck](https://docs.docker.com/compose/compose-file/#healthcheck)
![image](https://user-images.githubusercontent.com/3602533/88461392-b1722a00-ceab-11ea-990e-e90f1bfc35bb.png)
![Screen Shot 2020-07-25 at 7 22 42 PM](https://user-images.githubusercontent.com/3602533/88461454-47a65000-ceac-11ea-941d-07064ceb52b5.png)
