### PR TITLE
FLOWER-891 respect custom separator

### DIFF
--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -94,7 +94,7 @@ class RabbitMQ(BrokerBase):
 
 
 class RedisBase(BrokerBase):
-    SEP = '\x06\x16'
+    DEFAULT_SEP = '\x06\x16'
     DEFAULT_PRIORITY_STEPS = [0, 3, 6, 9]
 
     def __init__(self, broker_url, *args, **kwargs):
@@ -103,17 +103,14 @@ class RedisBase(BrokerBase):
         if not redis:
             raise ImportError('redis library is required')
 
-        broker_options = kwargs.get('broker_options')
-
-        if broker_options and 'priority_steps' in broker_options:
-            self.priority_steps = broker_options['priority_steps']
-        else:
-            self.priority_steps = self.DEFAULT_PRIORITY_STEPS
+        broker_options = kwargs.get('broker_options', {})
+        self.priority_steps = broker_options.get('priority_steps', self.DEFAULT_PRIORITY_STEPS)
+        self.sep = broker_options.get('sep', self.DEFAULT_SEP)
 
     def _q_for_pri(self, queue, pri):
         if pri not in self.priority_steps:
             raise ValueError('Priority not in priority steps')
-        return '{0}{1}{2}'.format(*((queue, self.SEP, pri) if pri else (queue, '', '')))
+        return '{0}{1}{2}'.format(*((queue, self.sep, pri) if pri else (queue, '', '')))
 
     @gen.coroutine
     def queues(self, names):

--- a/tests/unit/utils/test_broker.py
+++ b/tests/unit/utils/test_broker.py
@@ -57,6 +57,14 @@ class TestRedis(unittest.TestCase):
             b = Broker('redis://localhost:6379/0', broker_options=options)
             self.assertEqual(expected, b.priority_steps)
 
+    def test_custom_sep(self):
+        custom_sep = '.'
+        cases = [(RedisBase.DEFAULT_SEP, {}),
+                 (custom_sep, {'sep': custom_sep})]
+        for expected, options in cases:
+            b = Broker('redis://localhost:6379/0', broker_options=options)
+            self.assertEqual(expected, b.sep)
+
     def test_url(self):
         b = Broker('redis://foo:7777/9')
         self.assertEqual('foo', b.host)


### PR DESCRIPTION
#891 Respect the configured separator broker transport option for redis

I've marked this as a draft because I would like some feedback. I'm still testing it out locally (I'm having some issues, but not sure if its flower, or something else I've done wrong with custom separator on my celery workers

I'm seeing 
```
[W 200731 23:30:17 inspector:42] Inspect method reserved failed
[W 200731 23:30:17 inspector:42] Inspect method revoked failed
[W 200731 23:30:17 inspector:42] Inspect method stats failed
[W 200731 23:30:17 inspector:42] Inspect method conf failed
[W 200731 23:30:17 inspector:42] Inspect method registered failed
[W 200731 23:30:17 inspector:42] Inspect method scheduled failed
[W 200731 23:30:17 inspector:42] Inspect method active failed
[W 200731 23:30:17 inspector:42] Inspect method active_queues failed
```
but this is even with master flower without my changes. 
My worker shows this error `[2020-08-01 03:30:16,361: ERROR/MainProcess] Control command error: ValueError('too many values to unpack (expected 3)',)` (not your issue - just giving some context :D)