### PR TITLE
Logging is not lazy

### DIFF
--- a/flower/command.py
+++ b/flower/command.py
@@ -137,7 +137,7 @@ class FlowerCommand(Command):
                 options.address or 'localhost', options.port
             )
         else:
-            logger.info("Visit me via unix socket file: %s" % options.unix_socket)
+            logger.info("Visit me via unix socket file: %s", options.unix_socket)
 
         logger.info('Broker: %s', self.app.connection().as_uri())
         logger.info(

--- a/flower/views/broker.py
+++ b/flower/views/broker.py
@@ -42,7 +42,7 @@ class BrokerView(BaseHandler):
 
             queues = yield broker.queues(sorted(queue_names))
         except Exception as e:
-            logger.error("Unable to get queues: '%s'" % e)
+            logger.error("Unable to get queues: '%s'", e)
 
         self.render("broker.html",
                     broker_url=app.capp.connection().as_uri(),


### PR DESCRIPTION
The logging statement has the call of the form logging.`(format_string % (format_args...))`. For such calls, it is recommended to leave string interpolation to the logging method itself and be written as `logging.(format_string, format_args...)` so that the program may avoid incurring the cost of the interpolation in those cases in which no message will be logged. For more details, see [PEP 282.](http://www.python.org/dev/peps/pep-0282)

Not Preferred:
```
logger.info("This is a log message %s %d %d" % (msg, foo, bar))
```

Preferred: 
```
logger.info("This is a log message %s %d %d", msg, foo, bar)
```

Fix #1006 
Specifially https://deepsource.io/gh/pnijhara/flower/issue/PYL-W1201/occurrences
