### PR TITLE
Celery 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
         celery-version: [5.0]
         tornado-version: [5.0, 5.1, 6.0]
+        exclude:
+          - celery-version: 5.0
+            python-version: 3.9
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,19 +9,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        celery-version: [4.1, 4.2, 4.3, 4.4]
+        celery-version: [5.0.0, 5.0.1, 5.0.2]
         tornado-version: [5.0, 5.1, 6.0]
-        exclude:
-          - python-version: 3.7
-            celery-version: 4.1
-          - python-version: 3.7
-            celery-version: 4.2
-          - python-version: 3.8
-            celery-version: 4.1
-          - python-version: 3.8
-            celery-version: 4.2
-          - python-version: 3.8
-            celery-version: 4.3
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        celery-version: [5.0.0, 5.0.1, 5.0.2]
+        celery-version: [5.0]
         tornado-version: [5.0, 5.1, 6.0]
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
   - "pypy3"
 install:
   - pip install tox-travis

--- a/flower/__main__.py
+++ b/flower/__main__.py
@@ -1,15 +1,11 @@
-from flower.command import FlowerCommand
-from flower.utils import bugreport
+import sys
 
 
 def main():
-    try:
-        flower = FlowerCommand()
-        flower.execute_from_commandline()
-    except Exception:
-        import sys
-        print(bugreport(app=flower.app), file=sys.stderr)
-        raise
+    from celery.bin.celery import main as _main, celery
+    from flower.command import flower
+    celery.add_command(flower)
+    sys.exit(_main())
 
 
 if __name__ == "__main__":

--- a/flower/command.py
+++ b/flower/command.py
@@ -20,13 +20,14 @@ from .urls import settings
 from .utils import abs_path, prepend_url
 from .options import DEFAULT_CONFIG_FILE, default_options
 
-
 logger = logging.getLogger(__name__)
 ENV_VAR_PREFIX = 'FLOWER_'
 
 
 @click.command(cls=CeleryCommand,
-               context_settings={'allow_extra_args': True})
+               context_settings={
+                   'ignore_unknown_options': True
+               })
 @click.argument("torando_argv", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def flower(ctx, torando_argv):
@@ -123,7 +124,7 @@ def is_flower_option(arg):
 
 
 def is_flower_envvar(name):
-    return name.startswith(ENV_VAR_PREFIX) and\
+    return name.startswith(ENV_VAR_PREFIX) and \
            name[len(ENV_VAR_PREFIX):].lower() in default_options
 
 

--- a/flower/command.py
+++ b/flower/command.py
@@ -8,10 +8,11 @@ from pprint import pformat
 
 from logging import NullHandler
 
+import click
 from tornado.options import options
 from tornado.options import parse_command_line, parse_config_file
 from tornado.log import enable_pretty_logging
-from celery.bin.base import Command
+from celery.bin.base import CeleryCommand
 
 from . import __version__
 from .app import Flower
@@ -21,127 +22,134 @@ from .options import DEFAULT_CONFIG_FILE, default_options
 
 
 logger = logging.getLogger(__name__)
+ENV_VAR_PREFIX = 'FLOWER_'
 
 
-class FlowerCommand(Command):
-    ENV_VAR_PREFIX = 'FLOWER_'
-
-    def run_from_argv(self, prog_name, argv=None, **_kwargs):
-        self.apply_env_options()
-        self.apply_options(prog_name, argv)
-
-        self.extract_settings()
-        self.setup_logging()
-
-        self.app.loader.import_default_modules()
-        flower = Flower(capp=self.app, options=options, **settings)
-        atexit.register(flower.stop)
-
-        def sigterm_handler(signal, frame):
-            logger.info('SIGTERM detected, shutting down')
-            sys.exit(0)
-        signal.signal(signal.SIGTERM, sigterm_handler)
-
-        self.print_banner('ssl_options' in settings)
-
-        try:
-            flower.start()
-        except (KeyboardInterrupt, SystemExit):
-            pass
-
-    def handle_argv(self, prog_name, argv=None):
-        return self.run_from_argv(prog_name, argv)
-
-    def apply_env_options(self):
-        "apply options passed through environment variables"
-        env_options = filter(self.is_flower_envvar, os.environ)
-        for env_var_name in env_options:
-            name = env_var_name.replace(self.ENV_VAR_PREFIX, '', 1).lower()
-            value = os.environ[env_var_name]
-            try:
-                option = options._options[name]
-            except KeyError:
-                option = options._options[name.replace('_', '-')]
-            if option.multiple:
-                value = [option.type(i) for i in value.split(',')]
-            else:
-                value = option.type(value)
-            setattr(options, name, value)
-
-    def apply_options(self, prog_name, argv):
-        "apply options passed through the configuration file"
-        argv = list(filter(self.is_flower_option, argv))
-        # parse the command line to get --conf option
-        parse_command_line([prog_name] + argv)
-        try:
-            parse_config_file(os.path.abspath(options.conf), final=False)
-            parse_command_line([prog_name] + argv)
-        except IOError:
-            if os.path.basename(options.conf) != DEFAULT_CONFIG_FILE:
-                raise
-
-    def setup_logging(self):
-        if options.debug and options.logging == 'info':
-            options.logging = 'debug'
-            enable_pretty_logging()
-        else:
-            logging.getLogger("tornado.access").addHandler(NullHandler())
-            logging.getLogger("tornado.access").propagate = False
-
-    def extract_settings(self):
-        settings['debug'] = options.debug
-
-        if options.cookie_secret:
-            settings['cookie_secret'] = options.cookie_secret
-
-        if options.url_prefix:
-            for name in ['login_url', 'static_url_prefix']:
-                settings[name] = prepend_url(settings[name], options.url_prefix)
-
-        if options.auth:
-            settings['oauth'] = {
-                'key': options.oauth2_key or os.environ.get('FLOWER_OAUTH2_KEY'),
-                'secret': options.oauth2_secret or os.environ.get('FLOWER_OAUTH2_SECRET'),
-                'redirect_uri': options.oauth2_redirect_uri or os.environ.get('FLOWER_OAUTH2_REDIRECT_URI'),
-            }
-
-        if options.certfile and options.keyfile:
-            settings['ssl_options'] = dict(certfile=abs_path(options.certfile),
-                                           keyfile=abs_path(options.keyfile))
-            if options.ca_certs:
-                settings['ssl_options']['ca_certs'] = abs_path(options.ca_certs)
-
-    def early_version(self, argv):
-        if '--version' in argv:
-            if '--debug' in argv:
-                from flower.utils import bugreport
-                print(bugreport(), file=self.stdout)
-
-            print(__version__, file=self.stdout)
-            super(FlowerCommand, self).early_version(argv)
-
-    @staticmethod
-    def is_flower_option(arg):
-        name, _, _ = arg.lstrip('-').partition("=")
-        name = name.replace('-', '_')
-        return hasattr(options, name)
-
-    def is_flower_envvar(self, name):
-        return name.startswith(self.ENV_VAR_PREFIX) and\
-               name[len(self.ENV_VAR_PREFIX):].lower() in default_options
-
-    def print_banner(self, ssl):
-        if not options.unix_socket:
-            logger.info(
-                "Visit me at http%s://%s:%s", 's' if ssl else '',
-                options.address or 'localhost', options.port
-            )
-        else:
-            logger.info("Visit me via unix socket file: %s", options.unix_socket)
-
-        logger.info('Broker: %s', self.app.connection().as_uri())
+def print_banner(app, ssl):
+    if not options.unix_socket:
         logger.info(
-            'Registered tasks: \n%s',
-            pformat(sorted(self.app.tasks.keys()))
+            "Visit me at http%s://%s:%s", 's' if ssl else '',
+            options.address or 'localhost', options.port
         )
-        logger.debug('Settings: %s', pformat(settings))
+    else:
+        logger.info("Visit me via unix socket file: %s", options.unix_socket)
+
+    logger.info('Broker: %s', app.connection().as_uri())
+    logger.info(
+        'Registered tasks: \n%s',
+        pformat(sorted(app.tasks.keys()))
+    )
+    logger.debug('Settings: %s', pformat(settings))
+
+
+@click.command(cls=CeleryCommand,
+               context_settings={'allow_extra_args': True})
+@click.argument("torando_argv", nargs=-1, type=click.UNPROCESSED)
+@click.pass_context
+def flower(ctx, torando_argv):
+    apply_env_options()
+    apply_options(sys.argv[0], torando_argv)
+
+    extract_settings()
+    setup_logging()
+
+    app = ctx.obj.app
+    flower = Flower(capp=app, options=options, **settings)
+
+    atexit.register(flower.stop)
+
+    def sigterm_handler(signal, frame):
+        logger.info('SIGTERM detected, shutting down')
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, sigterm_handler)
+    print_banner(app, 'ssl_options' in settings)
+    try:
+        flower.start()
+    except (KeyboardInterrupt, SystemExit):
+        pass
+
+
+def apply_env_options():
+    "apply options passed through environment variables"
+    env_options = filter(is_flower_envvar, os.environ)
+    for env_var_name in env_options:
+        name = env_var_name.replace(ENV_VAR_PREFIX, '', 1).lower()
+        value = os.environ[env_var_name]
+        try:
+            option = options._options[name]
+        except KeyError:
+            option = options._options[name.replace('_', '-')]
+        if option.multiple:
+            value = [option.type(i) for i in value.split(',')]
+        else:
+            value = option.type(value)
+        setattr(options, name, value)
+
+
+def apply_options(prog_name, argv):
+    "apply options passed through the configuration file"
+    argv = list(filter(is_flower_option, argv))
+    # parse the command line to get --conf option
+    parse_command_line([prog_name] + argv)
+    try:
+        parse_config_file(os.path.abspath(options.conf), final=False)
+        parse_command_line([prog_name] + argv)
+    except IOError:
+        if os.path.basename(options.conf) != DEFAULT_CONFIG_FILE:
+            raise
+
+
+def setup_logging():
+    if options.debug and options.logging == 'info':
+        options.logging = 'debug'
+        enable_pretty_logging()
+    else:
+        logging.getLogger("tornado.access").addHandler(NullHandler())
+        logging.getLogger("tornado.access").propagate = False
+
+
+def extract_settings():
+    settings['debug'] = options.debug
+
+    if options.cookie_secret:
+        settings['cookie_secret'] = options.cookie_secret
+
+    if options.url_prefix:
+        for name in ['login_url', 'static_url_prefix']:
+            settings[name] = prepend_url(settings[name], options.url_prefix)
+
+    if options.auth:
+        settings['oauth'] = {
+            'key': options.oauth2_key or os.environ.get('FLOWER_OAUTH2_KEY'),
+            'secret': options.oauth2_secret or os.environ.get('FLOWER_OAUTH2_SECRET'),
+            'redirect_uri': options.oauth2_redirect_uri or os.environ.get('FLOWER_OAUTH2_REDIRECT_URI'),
+        }
+
+    if options.certfile and options.keyfile:
+        settings['ssl_options'] = dict(certfile=abs_path(options.certfile),
+                                       keyfile=abs_path(options.keyfile))
+        if options.ca_certs:
+            settings['ssl_options']['ca_certs'] = abs_path(options.ca_certs)
+
+
+def early_version(self, argv):
+    if '--version' in argv:
+        if '--debug' in argv:
+            from flower.utils import bugreport
+            print(bugreport(), file=self.stdout)
+
+        print(__version__, file=self.stdout)
+        super(FlowerCommand, self).early_version(argv)
+
+
+@staticmethod
+def is_flower_option(arg):
+    name, _, _ = arg.lstrip('-').partition("=")
+    name = name.replace('-', '_')
+    return hasattr(options, name)
+
+
+def is_flower_envvar(name):
+    return name.startswith(ENV_VAR_PREFIX) and\
+           name[len(ENV_VAR_PREFIX):].lower() in default_options

--- a/flower/command.py
+++ b/flower/command.py
@@ -25,23 +25,6 @@ logger = logging.getLogger(__name__)
 ENV_VAR_PREFIX = 'FLOWER_'
 
 
-def print_banner(app, ssl):
-    if not options.unix_socket:
-        logger.info(
-            "Visit me at http%s://%s:%s", 's' if ssl else '',
-            options.address or 'localhost', options.port
-        )
-    else:
-        logger.info("Visit me via unix socket file: %s", options.unix_socket)
-
-    logger.info('Broker: %s', app.connection().as_uri())
-    logger.info(
-        'Registered tasks: \n%s',
-        pformat(sorted(app.tasks.keys()))
-    )
-    logger.debug('Settings: %s', pformat(settings))
-
-
 @click.command(cls=CeleryCommand,
                context_settings={'allow_extra_args': True})
 @click.argument("torando_argv", nargs=-1, type=click.UNPROCESSED)
@@ -133,17 +116,6 @@ def extract_settings():
             settings['ssl_options']['ca_certs'] = abs_path(options.ca_certs)
 
 
-def early_version(self, argv):
-    if '--version' in argv:
-        if '--debug' in argv:
-            from flower.utils import bugreport
-            print(bugreport(), file=self.stdout)
-
-        print(__version__, file=self.stdout)
-        super(FlowerCommand, self).early_version(argv)
-
-
-@staticmethod
 def is_flower_option(arg):
     name, _, _ = arg.lstrip('-').partition("=")
     name = name.replace('-', '_')
@@ -153,3 +125,20 @@ def is_flower_option(arg):
 def is_flower_envvar(name):
     return name.startswith(ENV_VAR_PREFIX) and\
            name[len(ENV_VAR_PREFIX):].lower() in default_options
+
+
+def print_banner(app, ssl):
+    if not options.unix_socket:
+        logger.info(
+            "Visit me at http%s://%s:%s", 's' if ssl else '',
+            options.address or 'localhost', options.port
+        )
+    else:
+        logger.info("Visit me via unix socket file: %s", options.unix_socket)
+
+    logger.info('Broker: %s', app.connection().as_uri())
+    logger.info(
+        'Registered tasks: \n%s',
+        pformat(sorted(app.tasks.keys()))
+    )
+    logger.debug('Settings: %s', pformat(settings))

--- a/flower/command.py
+++ b/flower/command.py
@@ -31,6 +31,7 @@ ENV_VAR_PREFIX = 'FLOWER_'
 @click.argument("tornado_argv", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def flower(ctx, tornado_argv):
+    """Web based tool for monitoring and administrating Celery clusters."""
     apply_env_options()
     apply_options(sys.argv[0], tornado_argv)
 

--- a/flower/command.py
+++ b/flower/command.py
@@ -28,11 +28,11 @@ ENV_VAR_PREFIX = 'FLOWER_'
                context_settings={
                    'ignore_unknown_options': True
                })
-@click.argument("torando_argv", nargs=-1, type=click.UNPROCESSED)
+@click.argument("tornado_argv", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
-def flower(ctx, torando_argv):
+def flower(ctx, tornado_argv):
     apply_env_options()
-    apply_options(sys.argv[0], torando_argv)
+    apply_options(sys.argv[0], tornado_argv)
 
     extract_settings()
     setup_logging()

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-celery>=5.0.0; python_version>="3.7"
+celery>=5.0.0
 tornado>=5.0.0,<7.0.0
 prometheus_client==0.8.0
 humanize

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,4 @@
-celery>=4.3.0,<5.0.0; python_version>="3.7"
-vine==1.3.0
+celery>=5.0.0; python_version>="3.7"
 tornado>=5.0.0,<7.0.0
 prometheus_client==0.8.0
 humanize

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,5 @@ setup(
         'console_scripts': [
             'flower = flower.__main__:main',
         ],
-        'celery.commands': [
-            'flower = flower.command:FlowerCommand',
-        ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,8 @@ setup(
         'console_scripts': [
             'flower = flower.__main__:main',
         ],
+        'celery.commands': [
+            'flower = flower.command:flower',
+        ],
     },
 )

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 import subprocess
 
-from flower.command import FlowerCommand
+from flower.command import apply_options
 from tornado.options import options
 from tests.unit import AsyncHTTPTestCase
 
@@ -12,35 +12,30 @@ from tests.unit import AsyncHTTPTestCase
 class TestFlowerCommand(AsyncHTTPTestCase):
     def test_port(self):
         with self.mock_option('port', 5555):
-            command = FlowerCommand()
-            command.apply_options('flower', argv=['--port=123'])
+            apply_options('flower', argv=['--port=123'])
             self.assertEqual(123, options.port)
 
     def test_address(self):
         with self.mock_option('address', '127.0.0.1'):
-            command = FlowerCommand()
-            command.apply_options('flower', argv=['--address=foo'])
+            apply_options('flower', argv=['--address=foo'])
             self.assertEqual('foo', options.address)
 
 
 class TestConfOption(AsyncHTTPTestCase):
     def test_error_conf(self):
         with self.mock_option('conf', None):
-            command = FlowerCommand()
-            self.assertRaises(IOError, command.apply_options,
+            self.assertRaises(IOError, apply_options,
                               'flower', argv=['--conf=foo'])
-            self.assertRaises(IOError, command.apply_options,
+            self.assertRaises(IOError, apply_options,
                               'flower', argv=['--conf=/tmp/flower/foo'])
 
     def test_default_option(self):
-        command = FlowerCommand()
-        command.apply_options('flower', argv=[])
+        apply_options('flower', argv=[])
         self.assertEqual('flowerconfig.py', options.conf)
 
     def test_empty_conf(self):
         with self.mock_option('conf', None):
-            command = FlowerCommand()
-            command.apply_options('flower', argv=['--conf=/dev/null'])
+            apply_options('flower', argv=['--conf=/dev/null'])
             self.assertEqual('/dev/null', options.conf)
 
     def test_conf_abs(self):
@@ -48,8 +43,7 @@ class TestConfOption(AsyncHTTPTestCase):
             with self.mock_option('conf', cf.name), self.mock_option('debug', False):
                 cf.write('debug=True\n'.encode('utf-8'))
                 cf.flush()
-                command = FlowerCommand()
-                command.apply_options('flower', argv=['--conf=%s' % cf.name])
+                apply_options('flower', argv=['--conf=%s' % cf.name])
                 self.assertEqual(cf.name, options.conf)
                 self.assertTrue(options.debug)
 
@@ -58,8 +52,7 @@ class TestConfOption(AsyncHTTPTestCase):
             with self.mock_option('conf', cf.name), self.mock_option('debug', False):
                 cf.write('debug=True\n'.encode('utf-8'))
                 cf.flush()
-                command = FlowerCommand()
-                command.apply_options('flower', argv=['--conf=%s' % os.path.basename(cf.name)])
+                apply_options('flower', argv=['--conf=%s' % os.path.basename(cf.name)])
                 self.assertTrue(options.debug)
 
     @unittest.skipUnless(not sys.platform.startswith("win"), 'skip windows')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39,pypy3}-{celery500,celery501,celery502}-{tornado5,tornado6}
+envlist = {py36,py37,py38,py39,pypy3}-{celery50}-{tornado5,tornado6}
 skip_missing_interpreters = True
 
 [testenv]
@@ -7,9 +7,7 @@ deps =
     mock
     pytest
 setenv =
-    celery500: CELERY_VERSION=5.0.0
-    celery501: CELERY_VERSION=5.0.1
-    celery502: CELERY_VERSION=5.0.2
+    celery50: CELERY_VERSION=5.0
     tornado5: TORNADO_VERSION=>=5.0.0,<6.0.0
     tornado6: TORNADO_VERSION=>=6.0.0,<7.0.0
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39,pypy3}-{celery43,celery44}-{tornado5,tornado6}
+envlist = {py36,py37,py38,py39,pypy3}-{celery500,celery501,celery502}-{tornado5,tornado6}
 skip_missing_interpreters = True
 
 [testenv]
@@ -7,8 +7,9 @@ deps =
     mock
     pytest
 setenv =
-    celery43: CELERY_VERSION=4.3.0
-    celery44: CELERY_VERSION=4.4.0
+    celery500: CELERY_VERSION=5.0.0
+    celery501: CELERY_VERSION=5.0.1
+    celery502: CELERY_VERSION=5.0.2
     tornado5: TORNADO_VERSION=>=5.0.0,<6.0.0
     tornado6: TORNADO_VERSION=>=6.0.0,<7.0.0
 commands =


### PR DESCRIPTION
Celery 5 consists of a refactor to the CLI framework. The `celery` command and its sub-commands are now powered by Click.
In version 5.0.5, the ability to extend the base command was restored, and so in order to invoke flower on Celery >=5, <5.0.5 using this change, you would have to:
```
flower -A app flower 
```

For the newest patch, it can be executed as any other celery subcommand:
```
celery -A app flower
```

This change probably requires a major version upgrade as it has major version dependency upgrade for celery.
