### PR TITLE
Concurrent Futures are not usable with await. Wrap this in a Tornado

### DIFF
--- a/flower/app.py
+++ b/flower/app.py
@@ -80,7 +80,8 @@ class Flower(tornado.web.Application):
             self.started = False
 
     def delay(self, method, *args, **kwargs):
-        return self.pool.submit(partial(method, *args, **kwargs))
+        return self.io_loop.run_in_executor(
+            self.pool, partial(method, *args, **kwargs))
 
     @property
     def transport(self):


### PR DESCRIPTION
appearance: A `inspect method time out` error has occurred in python 2.7.5(flower 0.9.5).
`concurrent.futures.ThreadPoolExecutor` was added in Python-3.2 (and is not present in Python-2.7), and it returns instances of `concurrent.futures.Future` which are not compatible with the Python-3.4 `asyncio Futures`, and require some adaptation. The tornado ioloop has a helper function to do this:
https://www.tornadoweb.org/en/branch5.1/_modules/tornado/ioloop.html#IOLoop.run_in_executor
