### PR TITLE
Proposal: use jinja for flower templates in preparation for adding flask app support

### DIFF
--- a/flower/app.py
+++ b/flower/app.py
@@ -46,6 +46,10 @@ class Flower(tornado.web.Application):
         if options is not None and options.url_prefix:
             handlers = [rewrite_handler(h, options.url_prefix) for h in handlers]
         kwargs.update(handlers=handlers)
+
+        loader = kwargs["template_loader"]
+        loader.jinja2_environment.globals["reverse_url"] = self.reverse_url
+
         super(Flower, self).__init__(**kwargs)
         self.options = options or default_options
         self.io_loop = io_loop or ioloop.IOLoop.instance()

--- a/flower/templates/404.html
+++ b/flower/templates/404.html
@@ -7,7 +7,7 @@
                 {{ message }}
             {% else %}
                 Error, page not found
-            {% end %}
+            {% endif %}
         </p>
     </div>
-{% end %}
+{% endblock %}

--- a/flower/templates/base.html
+++ b/flower/templates/base.html
@@ -1,3 +1,5 @@
+{% import 'navbar.html' as navbar_macro %}
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/flower/templates/base.html
+++ b/flower/templates/base.html
@@ -1,4 +1,3 @@
-{% import pprint %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -24,7 +23,7 @@
     <link href="{{ static_url('css/jquery.dataTables.css') }}" rel="stylesheet">
 
     {% block extra_styles %}
-    {% end %}
+    {% endblock %}
 
     <!--[if lt IE 9]>
       <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
@@ -40,8 +39,8 @@
 
   <body>
     {% block navbar %}
-        {% module Template("navbar.html", active_tab="") %}
-    {% end %}
+      {{ navbar_macro.navbar(active_tab="") }}
+    {% endblock %}
 
     <div class="container-fluid">
       <div id="alert" class="alert alert-success hide">
@@ -52,7 +51,7 @@
     </div>
 
     {% block container %}
-    {% end %}
+    {% endblock %}
 
     <!-- Le javascript
     ================================================== -->
@@ -85,7 +84,7 @@
     <script src="{{ static_url('js/flower.js') }}"></script>
 
     {% block extra_scripts %}
-    {% end %}
+    {% endblock %}
 
   </body>
 </html>

--- a/flower/templates/broker.html
+++ b/flower/templates/broker.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% import 'navbar.html' as navbar_macro %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="broker") %}
-{% end %}
+  {{ navbar_macro.navbar(active_tab="broker") }}
+{% endblock %}
+
 
 {% block container %}
   <div class="container-fluid">
@@ -24,7 +26,7 @@
       </thead>
       <tbody>
       {% for queue in queues %}
-        <tr id="{{ url_escape(queue['name']) }}">
+        <tr id="{{ queue['name'] | escape }}">
             <td>{{ queue['name'] }}</td>
             <td>{{ queue.get('messages', 'N/A') }}</td>
             <td>{{ queue.get('messages_unacknowledged', 'N/A') }}</td>
@@ -32,9 +34,9 @@
             <td>{{ queue.get('consumers', 'N/A') }}</td>
             <td>{{ queue.get('idle_since', 'N/A') }}</td>
         </tr>
-      {% end %}
+      {% endfor %}
       </tbody>
      </table>
 
 </div>
-{% end %}
+{% endblock %}

--- a/flower/templates/dashboard.html
+++ b/flower/templates/dashboard.html
@@ -1,17 +1,18 @@
 {% extends "base.html" %}
+{% import 'navbar.html' as navbar_macro %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="dashboard")%}
-{% end %}
+  {{ navbar_macro.navbar(active_tab="dashboard") }}
+{% endblock %}
 
 {% block container %}
   <div class="container-fluid">
     <div class="btn-group btn-group-justified">
-        <a id="btn-active" class="btn btn-default btn-large" href="{{ reverse_url('tasks') }}?state=STARTED">Active: {{ sum(map(lambda x:x.get('active') or 0, workers.values() )) }}</a>
-        <a id="btn-processed" class="btn btn-default btn-large" href="{{ reverse_url('tasks') }}">Processed: {{ sum(map(lambda x:x.get('task-received') or 0, workers.values() )) }}</a>
-        <a id="btn-failed" class="btn btn-default btn-large" href="{{ reverse_url('tasks') }}?state=FAILURE">Failed: {{ sum(map(lambda x:x.get('task-failed') or 0, workers.values() )) }}</a>
-        <a id="btn-succeeded" class="btn btn-default btn-large" href="{{ reverse_url('tasks') }}?state=SUCCESS">Succeeded: {{ sum(map(lambda x:x.get('task-succeeded') or 0, workers.values() )) }}</a>
-        <a id="btn-retried" class="btn btn-default btn-large" href="{{ reverse_url('tasks') }}?state=RETRY">Retried: {{ sum(map(lambda x:x.get('task-retried') or 0, workers.values() )) }}</a>
+        <a id="btn-active" class="btn btn-default btn-large" href="{{ reverse_url('tasks') }}?state=STARTED">Active: {{ workers|accumulate('active') }}</a>
+        <a id="btn-processed" class="btn btn-default btn-large" href="{{ reverse_url('tasks') }}">Processed: {{ workers|accumulate('task-received') }}</a>
+        <a id="btn-failed" class="btn btn-default btn-large" href="{{ reverse_url('tasks') }}?state=FAILURE">Failed: {{ workers|accumulate('task-failed') }}</a>
+        <a id="btn-succeeded" class="btn btn-default btn-large" href="{{ reverse_url('tasks') }}?state=SUCCESS">Succeeded: {{ workers|accumulate('task-succeeded') }}</a>
+        <a id="btn-retried" class="btn btn-default btn-large" href="{{ reverse_url('tasks') }}?state=RETRY">Retried: {{ workers|accumulate('task-retried') }}</a>
     </div>
 
     <div class="panel panel-default">
@@ -32,7 +33,7 @@
       </thead>
       <tbody>
         {% for name, info in workers.items() %}
-        <tr id="{{ url_escape(name) }}">
+        <tr id="{{ name }}">
             <td>{{ name }}</td>
             <td>{{ info.get('status', None) }}</td>
             <td>{{ info.get('active', 0) or 0 }}</td>
@@ -42,17 +43,17 @@
             <td>{{ info.get('task-retried', 0) }}</td>
             <td>{{ humanize(info.get('loadavg', 'N/A')) }}</td>
         </tr>
-        {% end %}
+        {% endfor %}
       </tbody>
     </table>
 
         </div>
     </div>
 
-{% end %}
+{% endblock %}
 
 {% block extra_scripts %}
 <script type="text/javascript">
   var autorefresh = {{ autorefresh }};
 </script>
-{% end %}
+{% endblock %}

--- a/flower/templates/navbar.html
+++ b/flower/templates/navbar.html
@@ -1,3 +1,4 @@
+{% macro navbar(active_tab) -%}
 <div class="navbar navbar-fixed-top">
   <div class="navbar-inner">
     <div class="container-fluid">
@@ -9,9 +10,9 @@
       <a class="brand" href="{{ reverse_url('main') }}">Flower</a>
       <div class="nav-collapse collapse">
         <ul class="nav">
-            <li {% if active_tab == "dashboard" %}class="active"{% end %}><a href="{{ reverse_url('dashboard') }}">Dashboard</a></li>
-            <li {% if active_tab == "tasks" %}class="active"{% end %}><a href="{{ reverse_url('tasks') }}">Tasks</a></li>
-            <li {% if active_tab == "broker" %}class="active"{% end %}><a href="{{ reverse_url('broker') }}">Broker</a></li>
+            <li {% if active_tab == "dashboard" %}class="active"{% endif %}><a href="{{ reverse_url('dashboard') }}">Dashboard</a></li>
+            <li {% if active_tab == "tasks" %}class="active"{% endif %}><a href="{{ reverse_url('tasks') }}">Tasks</a></li>
+            <li {% if active_tab == "broker" %}class="active"{% endif %}><a href="{{ reverse_url('broker') }}">Broker</a></li>
         </ul>
         <ul class="nav pull-right">
           <li><a href="https://flower.readthedocs.io" target="_blank">Docs</a></li>
@@ -21,3 +22,4 @@
     </div>
   </div>
 </div>
+{% endmacro -%}

--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% import 'navbar.html' as navbar_macro %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="tasks") %}
-{% end %}
+  {{ navbar_macro.navbar(active_tab="tasks") }}
+{% endblock %}
+
 
 {% block container %}
   <div id='task-page' class="container-fluid">

--- a/flower/templates/tasks.html
+++ b/flower/templates/tasks.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
+{% import 'navbar.html' as navbar_macro %}
 
 {% block navbar %}
-  {% module Template("navbar.html", active_tab="tasks") %}
-{% end %}
-
+  {{ navbar_macro.navbar(active_tab="tasks") }}
+{% endblock %}
 
 {% block container %}
 <input type="hidden" value="{{ time }}" id='time'>
@@ -35,9 +35,9 @@
     </thead>
     <tbody>
     {% for uuid, task in tasks %}
-        {% if getattr(task, 'name', None) is None %}
+        {% if getattr(task, 'name', None) %}
             {% continue %}
-        {% end %}
+        {% endif %}
     <tr>
       <td>{{ task.name }}</td>
       <td>{{ task.uuid }}</td>
@@ -49,14 +49,14 @@
             {{ task.result }}
         {% elif task.state == "FAILURE" %}
             {{ task.exception }}
-        {% end %}
+        {% endif %}
       </td>
       <td>{{ humanize(task.received, type='time') }}</td>
       <td>{{ humanize(task.started, type='time') }}</td>
       <td>
         {% if task.timestamp and task.started %}
             {{ '%.2f' % humanize(task.timestamp - task.started) }} sec
-        {% end %}
+        {% endif %}
       </td>
       <td>{{ task.worker }}</td>
       <td>{{ task.exchange }}</td>
@@ -67,8 +67,8 @@
       <td>{{ task.expires }}</td>
       <td>{{ task.eta }}</td>
     </tr>
-      {% end %}
+      {% endfor %}
     </tbody>
   </table>
 </div>
-{% end %}
+{% endblock %}

--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -3,9 +3,10 @@
 
 {% block container %}
 
+{#
   {% set other = {key: value for key, value in worker['stats'].items() if key not in
                   'pool pid prefetch_count autoscaler consumer broker clock total rusage'.split()} %}
-
+#}
   <div class="container-fluid">
     <div class="row-fluid">
       <div class="span12">
@@ -37,7 +38,7 @@
             <li><a href="#tab-system" data-toggle="tab">System</a></li>
             {% if other %}
             <li><a href="#tab-other" data-toggle="tab">Other</a></li>
-            {% end %}
+            {% endif %}
           </ul>
 
           <div class="tab-content">
@@ -53,7 +54,7 @@
                           <td>{{ humanize(name) }}</td>
                           <td>{{ humanize(value) }}</td>
                         </tr>
-                      {% end %}
+                      {% endfor %}
                         <tr>
                             <td>Worker PID</td>
                             <td>{{ worker['stats'].get('pid', 'N/A')}}</td>
@@ -113,12 +114,12 @@
                                 <td>{{ humanize(name) }}</td>
                                 <td>{{ humanize(value) }}</td>
                                 </tr>
-                            {% end %}
+                            {% endfor %}
                             </tbody>
                         </table>
                     </div>
                 </div>
-              {% end %}
+              {% endif %}
 
             </div> <!-- end pool tab -->
 
@@ -132,7 +133,7 @@
                         <td>{{ humanize(name) }}</td>
                         <td>{{ value }}</td>
                       </tr>
-                    {% end %}
+                    {% endfor %}
                   </tbody>
                 </table>
               </div>
@@ -181,7 +182,7 @@
                       <td>{{ queue['auto_delete'] }}</td>
                       <td><button class="btn btn-danger" onclick="flower.on_cancel_consumer(event)">Cancel Consumer</button></td>
                   </tr>
-                {% end %}
+                {% endfor %}
               </tbody>
               </table>
             </div> <!-- end queues tab -->
@@ -195,7 +196,7 @@
                       <td>{{ name }}</td>
                       <td>{{ value }}</td>
                     </tr>
-                  {% end %}
+                  {% endfor %}
                   </tbody>
               </table>
 
@@ -221,7 +222,7 @@
                       <td>{{ task.get('args', 'N/A') }}</td>
                       <td>{{ task.get('kwargs', 'N/A') }}</td>
                     </tr>
-                  {% end %}
+                  {% endfor %}
                 </tbody>
               </table>
 
@@ -243,7 +244,7 @@
                       <td>{{ task['request']['args'] }}</td>
                       <td>{{ task['request']['kwargs'] }}</td>
                     </tr>
-                  {% end %}
+                  {% endfor %}
                   </tbody>
               </table>
 
@@ -265,7 +266,7 @@
                       <td>{{ task['args'] }}</td>
                       <td>{{ task['kwargs'] }}</td>
                     </tr>
-                  {% end %}
+                  {% endfor %}
                   </tbody>
               </table>
 
@@ -281,7 +282,7 @@
                     <tr>
                       <td><a href="{{ reverse_url('task', task) }}">{{ task }}</a></td>
                     </tr>
-                  {% end %}
+                  {% endfor %}
                 </tbody>
               </table>
             </div> <!-- end tasks tab -->
@@ -321,7 +322,7 @@
                       </div>
                     </td>
                   </tr>
-                {% end %}
+                {% endfor %}
               </table>
           </div> <!-- end limits tab -->
 
@@ -331,13 +332,13 @@
                 <caption>Configuration options</caption>
                 <tbody>
                 {% for name,value in sorted(worker.get('conf', {}).items()) %}
-                    {% if value is not None %}
+                    {% if value != None %}
                       <tr>
                         <td><a href="http://docs.celeryproject.org/en/latest/userguide/configuration.html#{{ name.lower().replace('_', '-') }}" target="_blank">{{ name }}</a></td>
                         <td>{{ value }}</td>
                       </tr>
-                    {% end %}
-                  {% end %}
+                    {% endif %}
+                  {% endfor %}
                 </tbody>
               </table>
             </div>
@@ -354,8 +355,8 @@
                             <td>{{ name }}</td>
                             <td>{{ value }}</td>
                         </tr>
-                    {% end %}
-                {% end %}
+                    {% endfor %}
+                {% endif %}
                 </tbody>
               </table>
             </div>
@@ -372,16 +373,16 @@
                         <td>{{ name }}</td>
                         <td>{{ value }}</td>
                     </tr>
-                {% end %}
+                {% endfor %}
                 </tbody>
               </table>
             </div>
           </div> <!-- end other tab -->
-          {% end %}
+          {% endif %}
 
          </div>
         </div>
       </div>
   </div>
   </div>
-{% end %}
+{% endblock %}

--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -331,7 +331,7 @@
               <table class="table table-bordered table-striped">
                 <caption>Configuration options</caption>
                 <tbody>
-                {% for name,value in sorted(worker.get('conf', {}).items()) %}
+                {% for name,value in worker.get('conf', {}).items()|sort %}
                     {% if value != None %}
                       <tr>
                         <td><a href="http://docs.celeryproject.org/en/latest/userguide/configuration.html#{{ name.lower().replace('_', '-') }}" target="_blank">{{ name }}</a></td>
@@ -349,7 +349,7 @@
               <table class="table table-bordered table-striped">
                 <caption>System usage statistics</caption>
                 <tbody>
-                {% if isinstance(worker['stats'].get('rusage', None), dict) %}
+                {% if worker['stats'].get('rusage', None) is mapping %}
                     {% for name, value in worker['stats']['rusage'].items() %}
                         <tr>
                             <td>{{ name }}</td>

--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -1,8 +1,5 @@
 {% extends "base.html" %}
 
-{% block navbar %}
-  {% module Template("navbar.html", active_tab="workers") %}
-{% end %}
 
 {% block container %}
 

--- a/flower/urls.py
+++ b/flower/urls.py
@@ -18,7 +18,10 @@ from .views.dashboard import DashboardView
 from .utils import gen_cookie_secret
 
 # Create a instance of Jinja2Loader
-jinja2_env = jinja2.Environment(loader=jinja2.FileSystemLoader('./flower/templates'), autoescape=False)
+jinja2_env = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__), "templates")),
+    autoescape=False,
+)
 jinja2_loader = Jinja2Loader(jinja2_env)
 
 
@@ -33,13 +36,11 @@ def debug(text):
 
 jinja2_env.filters['debug'] = debug
 jinja2_env.filters['accumulate'] = accumulate
-jinja2_env.filters['reverse_url'] = debug
 jinja2_env.globals['reverse_url'] = debug
 
 
 settings = dict(
     template_loader=jinja2_loader,
-    # template_path=os.path.join(os.path.dirname(__file__), "templates"),
     static_path=os.path.join(os.path.dirname(__file__), "static"),
     cookie_secret=gen_cookie_secret(),
     static_url_prefix='/static/',

--- a/flower/urls.py
+++ b/flower/urls.py
@@ -1,6 +1,8 @@
 import os
 
+import jinja2
 from tornado.web import StaticFileHandler, url
+from tornado_jinja2 import Jinja2Loader
 
 from .api import events
 from .api import control
@@ -15,9 +17,29 @@ from .views.error import NotFoundErrorHandler
 from .views.dashboard import DashboardView
 from .utils import gen_cookie_secret
 
+# Create a instance of Jinja2Loader
+jinja2_env = jinja2.Environment(loader=jinja2.FileSystemLoader('./flower/templates'), autoescape=False)
+jinja2_loader = Jinja2Loader(jinja2_env)
+
+
+def accumulate(arr, attribute):
+    return sum(map(lambda x: x.get(attribute) or 0, arr.values()))
+
+
+def debug(text):
+    print(text)
+    return ''
+
+
+jinja2_env.filters['debug'] = debug
+jinja2_env.filters['accumulate'] = accumulate
+jinja2_env.filters['reverse_url'] = debug
+jinja2_env.globals['reverse_url'] = debug
+
 
 settings = dict(
-    template_path=os.path.join(os.path.dirname(__file__), "templates"),
+    template_loader=jinja2_loader,
+    # template_path=os.path.join(os.path.dirname(__file__), "templates"),
     static_path=os.path.join(os.path.dirname(__file__), "static"),
     cookie_secret=gen_cookie_secret(),
     static_url_prefix='/static/',

--- a/flower/urls.py
+++ b/flower/urls.py
@@ -36,7 +36,6 @@ def debug(text):
 
 jinja2_env.filters['debug'] = debug
 jinja2_env.filters['accumulate'] = accumulate
-jinja2_env.globals['reverse_url'] = debug
 
 
 settings = dict(

--- a/flower/urls.py
+++ b/flower/urls.py
@@ -21,6 +21,7 @@ from .utils import gen_cookie_secret
 jinja2_env = jinja2.Environment(
     loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__), "templates")),
     autoescape=False,
+    extensions=['jinja2.ext.loopcontrols']
 )
 jinja2_loader = Jinja2Loader(jinja2_env)
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,3 +5,5 @@ tornado>=5.0.0,<7.0.0; python_version>="3.5.2"
 prometheus_client==0.8.0
 humanize
 pytz
+jinja2
+tornado-jinja2==0.2.4


### PR DESCRIPTION
I am trying to get flower running as a flask blueprint and I realized we could change templates to jinja so they can be shared. I'm submitting this PR both for your consideration and to check if it breaks CI.
I also would like to emphasize that celery is migrating commands to `click`, so other pallets dependencies might be coming into flower, which is why I think this might be acceptable.