### PR TITLE
avoid calling quote() on '/' with invalid results

### DIFF
--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -45,7 +45,7 @@ class RabbitMQ(BrokerBase):
 
         self.host = self.host or 'localhost'
         self.port = self.port or 15672
-        self.vhost = quote(self.vhost, '') or '/'
+        self.vhost = quote(self.vhost, '') or '/' if self.vhost != '/' else self.vhost
         self.username = self.username or 'guest'
         self.password = self.password or 'guest'
 

--- a/tests/unit/utils/test_broker.py
+++ b/tests/unit/utils/test_broker.py
@@ -24,6 +24,14 @@ class TestRabbitMQ(unittest.TestCase):
         self.assertEqual('user', b.username)
         self.assertEqual('pass', b.password)
 
+    def test_url_vhost_slash(self):
+        b = RabbitMQ('amqp://user:pass@host:10000//', '')
+        self.assertEqual('host', b.host)
+        self.assertEqual(10000, b.port)
+        self.assertEqual('/', b.vhost)
+        self.assertEqual('user', b.username)
+        self.assertEqual('pass', b.password)
+
     def test_url_defaults_rabbitmq(self):
         for url in ['amqp://', 'amqp://localhost']:
             b = RabbitMQ(url, '')


### PR DESCRIPTION
not sure if this is pertinent but the results on calling quote() on '/' is '%2F'