### PR TITLE
remove vine==1.3.0 to solve depndency break with celery==5.0.5

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,7 +1,6 @@
 celery>=4.3.0,<5.0.0; python_version>="3.7"
 vine==1.3.0
 tornado>=5.0.0,<7.0.0; python_version>="3.5.2"
-vine==1.3.0
 prometheus_client==0.8.0
 humanize
 pytz


### PR DESCRIPTION
Fix issue #1053 by removing vine==1.3.0 from requirements/defaults.txt