### PR TITLE
Humanize the revoked time in the task template

### DIFF
--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -69,7 +69,7 @@
                 <tr>
                   <td>{{ humanize(name) }}</td>
                   <td>
-                    {% if name in ['sent', 'received', 'started', 'succeeded', 'retried', 'timestamp', 'failed'] %}
+                    {% if name in ['sent', 'received', 'started', 'succeeded', 'retried', 'timestamp', 'failed', 'revoked'] %}
                     {{ humanize(getattr(task, name, None), type='time') }}
                     {% elif name == 'worker' %}
                     <a


### PR DESCRIPTION
Previously this was just showing the raw time since epoch:
![2021-01-15 08:31:31](https://user-images.githubusercontent.com/1423728/104753568-0c733400-570d-11eb-97d6-dab1833dc0e1.png)

Thought it'd be more consistent to have the humanized time like we do for some of the other datetime fields.