### PR TITLE
Update CI Config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         celery-version: [4.1, 4.2, 4.3, 4.4]
         tornado-version: [5.0, 5.1, 6.0]
         exclude:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         celery-version: [4.1, 4.2, 4.3, 4.4]
         tornado-version: [5.0, 5.1, 6.0]
         exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 language: python
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 os:
   - linux
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 celery>=4.3.0,<5.0.0; python_version>="3.7"
 vine==1.3.0
-tornado>=5.0.0,<7.0.0; python_version>="3.5.2"
+tornado>=5.0.0,<7.0.0
 prometheus_client==0.8.0
 humanize
 pytz

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ classes = """
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ classes = """
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent


### PR DESCRIPTION
* Remove deprecated Python version (3.5)
* Update Travis env from Xenial (16.04) to Focal (20.04)
* Add Python 3.9 to CI config

Celery doesn't support Python 3.9 officially, yet tests seem to pass https://github.com/celery/celery/pull/6486 I see no reason for not to add 3.9 in the test matrix.

I also checked exclude section of `.github/workflows/build.yml`, but I couldn't understand how that list was generated or what should I add for 3.9

```
exclude:
  - python-version: 3.7
    celery-version: 4.1
  - python-version: 3.7
    celery-version: 4.2
  - python-version: 3.8
    celery-version: 4.1
  - python-version: 3.8
    celery-version: 4.2
  - python-version: 3.8
    celery-version: 4.3
```


