### PR TITLE
Check if broker and nodes are ready before starting Flower in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,16 @@ ENV PYTHONPATH ${FLOWER_DATA_DIR}
 
 WORKDIR $FLOWER_DATA_DIR
 
+COPY ./wait-for-broker.sh .
+
 # Add a user with an explicit UID/GID and create necessary directories
 RUN set -eux; \
     addgroup -g 1000 flower; \
     adduser -u 1000 -G flower flower -D; \
     mkdir -p "$FLOWER_DATA_DIR"; \
-    chown flower:flower "$FLOWER_DATA_DIR"
+    chown -R flower:flower "$FLOWER_DATA_DIR"
 USER flower
 
 VOLUME $FLOWER_DATA_DIR
 
-ENTRYPOINT ["flower"]
+ENTRYPOINT ["sh", "./wait-for-broker.sh", "flower"]

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,8 @@ Launch using docker: ::
 
     $ docker run -p 5555:5555 mher/flower
 
+To skip Docker health check add `-e FLOWER_SKIP_BROKER_READY=1` to set environment variable. To let start without checking nodes add `-e FLOWER_SKIP_NODE_CHECK=1`.
+
 Launch with unix socket file: ::
 
     $ flower --unix-socket=/tmp/flower.sock

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Launch using docker: ::
 
     $ docker run -p 5555:5555 mher/flower
 
-To skip Docker health check add `-e FLOWER_SKIP_BROKER_READY=1` to set environment variable. To let it start without checking nodes add `-e FLOWER_SKIP_NODE_CHECK=1`.
+To skip broker readiness in Docker add `-e FLOWER_SKIP_BROKER_READY=1` to set environment variable. To let it start without checking nodes add `-e FLOWER_SKIP_NODE_CHECK=1`.
 
 Launch with unix socket file: ::
 

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Launch using docker: ::
 
     $ docker run -p 5555:5555 mher/flower
 
-To skip Docker health check add `-e FLOWER_SKIP_BROKER_READY=1` to set environment variable. To let start without checking nodes add `-e FLOWER_SKIP_NODE_CHECK=1`.
+To skip Docker health check add `-e FLOWER_SKIP_BROKER_READY=1` to set environment variable. To let it start without checking nodes add `-e FLOWER_SKIP_NODE_CHECK=1`.
 
 Launch with unix socket file: ::
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -16,3 +16,4 @@ container and open http://localhost:49555 ::
 For more information about running with Docker see
 https://docs.docker.com/
 
+Flower starts after checking broker and nodes (workers) availability. If you want Flower to start after the broker is ready and don't want to check nodes, add `-e FLOWER_SKIP_NODE_CHECK=1` environment variable. If you want to completely skip checks add `-e FLOWER_SKIP_BROKER_READY=1`.

--- a/wait-for-broker.sh
+++ b/wait-for-broker.sh
@@ -1,0 +1,28 @@
+cmd="$@"
+
+if [ ! -z "$FLOWER_SKIP_BROKER_READY" ]; then
+	>&2 echo "Skipping broker readiness, executing command"
+	exec $cmd
+fi
+
+while true;
+do
+	timeout 10 celery inspect ping
+	STATUS=$?
+
+	if [[ "$STATUS" == "143" ]]; then
+		>&2 echo "Broker isn't responding"
+		continue
+	fi
+
+	if [ -z "$FLOWER_SKIP_NODE_CHECK" ] && [[ "$STATUS" == "69" ]]; then
+		>&2 echo "Nodes aren't responding"
+		continue
+	fi
+
+	break
+
+done
+
+>&2 echo "Broker ready, executing command"
+exec $cmd


### PR DESCRIPTION
I've noticed that if Flower starts before the broker inside Docker it then can't connect and therefore can't provide statistics. I'm not talking here about Docker Compose way.

So here is a somewhat simple solution. If broker and nodes are ready it starts Flower. Also, checks can be disabled via environment variables. E.g. to completely skip checking broker we can add `FLOWER_SKIP_BROKER_READY=1`. And it will start Flower as it does now. Or `FLOWER_SKIP_NODE_CHECK=1` allows to just check if the broker is ready but skip checking nodes/workers.

I'm not sure how to make it better in terms of current users. In my implementation checks will run unless environment variables are provided. Or maybe it's better to enable checks by providing such variables.

I'm open for discussion and hope we'll come to a solution that suits us all.

And of course, thank you for this amazing tool!