### PR TITLE
Fixes issue where 'active' key can be missing in worker-heartbeat event dict

### DIFF
--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -1,0 +1,3 @@
+# broker_url = 'redis://localhost:6379/0'
+# celery_result_backend = 'redis://localhost:6379/0'
+# task_send_sent_event = False

--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -1,3 +1,0 @@
-# broker_url = 'redis://localhost:6379/0'
-# celery_result_backend = 'redis://localhost:6379/0'
-# task_send_sent_event = False

--- a/flower/events.py
+++ b/flower/events.py
@@ -74,7 +74,10 @@ class EventsState(State):
 
         if event_type == 'worker-heartbeat':
             self.metrics.worker_online.labels(worker_name).set(1)
-            self.metrics.worker_number_of_currently_executing_tasks.labels(worker_name).set(event['active'])
+
+            num_executing_tasks = event.get('active')
+            if num_executing_tasks is not None:
+                self.metrics.worker_number_of_currently_executing_tasks.labels(worker_name).set(num_executing_tasks)
 
         if event_type == 'worker-offline':
             self.metrics.worker_online.labels(worker_name).set(0)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-celery>=5.0.0
+celery>=5.0.5
 tornado>=5.0.0,<7.0.0
 prometheus_client>=0.8.0
 humanize

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39,pypy3}-{celery50}-{tornado5,tornado6}
+envlist = {py36,py37,py38,py39,pypy3}-{celery505}-{tornado5,tornado6}
 skip_missing_interpreters = True
 
 [testenv]
@@ -7,7 +7,7 @@ deps =
     mock
     pytest
 setenv =
-    celery50: CELERY_VERSION=5.0
+    celery505: CELERY_VERSION=5.0.5
     tornado5: TORNADO_VERSION=>=5.0.0,<6.0.0
     tornado6: TORNADO_VERSION=>=6.0.0,<7.0.0
 commands =


### PR DESCRIPTION
This is an intermittent error produced by celery itself.

Their docs specify that the signature of worker-heartbeat event contains 'active' key (https://docs.celeryproject.org/en/stable/userguide/monitoring.html#worker-heartbeat).

Nonetheless if one keeps rebooting flower dozens of times eventually it will start with initial worker-heartbeat event from already running celery app with missing 'active' key.
I put a guard against it.