### PR TITLE
Fix autodiscovery

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -95,3 +95,4 @@ Simon Gurcke
 Jason Held
 Lukas Matta
 Tomasz Kluczkowski
+Alexey Nikitenko

--- a/flower/app.py
+++ b/flower/app.py
@@ -52,6 +52,8 @@ class Flower(tornado.web.Application):
         self.ssl_options = kwargs.get('ssl_options', None)
 
         self.capp = capp or celery.Celery()
+        self.capp.loader.import_default_modules()
+
         self.executor = self.pool_executor_cls(max_workers=self.max_workers)
         self.io_loop.set_default_executor(self.executor)
 

--- a/flower/command.py
+++ b/flower/command.py
@@ -39,6 +39,7 @@ def flower(ctx, tornado_argv):
     setup_logging()
 
     app = ctx.obj.app
+    app.loader.import_default_modules()
     flower = Flower(capp=app, options=options, **settings)
 
     atexit.register(flower.stop)

--- a/flower/command.py
+++ b/flower/command.py
@@ -39,7 +39,6 @@ def flower(ctx, tornado_argv):
     setup_logging()
 
     app = ctx.obj.app
-    app.loader.import_default_modules()
     flower = Flower(capp=app, options=options, **settings)
 
     atexit.register(flower.stop)

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -16,8 +16,13 @@ from flower import command  # noqa: F401 side effect - define options
 
 
 class AsyncHTTPTestCase(tornado.testing.AsyncHTTPTestCase):
-    def get_app(self):
-        capp = celery.Celery()
+
+    def _get_celery_app(self):
+        return celery.Celery()
+
+    def get_app(self, capp=None):
+        if not capp:
+            capp = self._get_celery_app()
         events = Events(capp)
         app = Flower(capp=capp, events=events,
                      options=options, handlers=handlers, **settings)

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -4,6 +4,8 @@ import tempfile
 import unittest
 import subprocess
 
+import mock
+
 from flower.command import apply_options
 from tornado.options import options
 from tests.unit import AsyncHTTPTestCase
@@ -19,6 +21,21 @@ class TestFlowerCommand(AsyncHTTPTestCase):
         with self.mock_option('address', '127.0.0.1'):
             apply_options('flower', argv=['--address=foo'])
             self.assertEqual('foo', options.address)
+
+    def test_autodiscovery(self):
+        """
+        Simulate basic Django setup:
+        - creating celery app
+        - run app.autodiscover_tasks()
+        - create flower command
+        """
+        celery_app = self._get_celery_app()
+        with mock.patch.object(celery_app, '_autodiscover_tasks') as autodiscover:
+            celery_app.autodiscover_tasks()
+
+            self.get_app(capp=celery_app)
+
+            self.assertTrue(autodiscover.called)
 
 
 class TestConfOption(AsyncHTTPTestCase):


### PR DESCRIPTION
Fixes this [issue](https://github.com/mher/flower/issues/1097)

Root cause of this issue is Celery autodiscovery feature is not working:
- celery_app.autodiscover_tasks method (without force flag) only connects to celery import_modules signal;
- import_modules signal sent only after calling import_default_modules() method. Other common subcommands for celery (like [worker, beat](https://github.com/celery/celery/blob/master/celery/loaders/base.py#L111), [report](https://github.com/celery/celery/blob/master/celery/bin/celery.py#L157), [shell](https://github.com/celery/celery/blob/master/celery/bin/shell.py#L137)) call this method manually.