### PR TITLE
Update command line instructions and invocation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,13 +57,33 @@ Development version: ::
 Usage
 -----
 
-Launch the server and open http://localhost:5555: ::
+**Important** Please note that from version 1.0.1 Flower supports Celery 5.
+This is a non-backwards compatible change, same as Celery 5 is not backwards compatible with the previous way of using
+their commands.
 
-    $ flower --port=5555
+With this comes the new way of launching
+`celery command with a subcommand <https://docs.celeryproject.org/en/stable/reference/cli.html#celery>`_
 
-Launch from celery: ::
+The key takeaway here is that the Celery app's arguments have to be specified after the `celery` command and Flower's
+arguments have to be specified after the `flower` sub-command.
 
-    $ celery flower -A proj --address=127.0.0.1 --port=5555
+This is the template to follow::
+
+    celery [OPTIONS] COMMAND [ARGS]
+
+Core Celery args that you may want to set::
+
+    -A, --app
+    -b, --broker
+    --result-backend
+
+Launch the flower server at specified port other than default 5555 (open http://localhost:5566): ::
+
+    $ celery flower --port=5566
+
+Specify address and port for Flower: ::
+
+    $ celery -A proj flower  --address=127.0.0.1 --port=5555
 
 Launch using docker: ::
 
@@ -71,11 +91,11 @@ Launch using docker: ::
 
 Launch with unix socket file: ::
 
-    $ flower --unix-socket=/tmp/flower.sock
+    $ celery flower --unix-socket=/tmp/flower.sock
 
-Broker URL and other configuration options can be passed through the standard Celery options: ::
+Broker URL and other configuration options can be passed through the standard Celery options (notice that they are after celery command and before flower sub-command: ::
 
-    $ celery flower -A proj --broker=amqp://guest:guest@localhost:5672//
+    $ celery -A proj --broker=amqp://guest:guest@localhost:5672// flower
 
 API
 ---

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Launch the Flower server at specified port other than default 5555 (open the UI 
 
 Specify Celery application path with address and port for Flower: ::
 
-    $ celery -A 'tasks' flower  --address=127.0.0.6 --port=5566
+    $ celery -A proj flower --address=127.0.0.6 --port=5566
 
 Launch using docker: ::
 
@@ -99,7 +99,7 @@ Launch with unix socket file: ::
 Broker URL and other configuration options can be passed through the standard Celery options (notice that they are after
 Celery command and before Flower sub-command): ::
 
-    $ celery --broker=amqp://guest:guest@localhost:5672// flower
+    $ celery -A proj --broker=amqp://guest:guest@localhost:5672// flower
 
 API
 ---

--- a/README.rst
+++ b/README.rst
@@ -46,13 +46,13 @@ Features
 Installation
 ------------
 
-PyPI version: ::
+Installing `flower` with `pip <http://www.pip-installer.org/>`_ is simple ::
 
     $ pip install flower
 
-Development version: ::
+Development version can be installed with ::
 
-    $ pip install https://github.com/mher/flower/zipball/master
+    $ pip install https://github.com/mher/flower/zipball/master#egg=flower
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -57,19 +57,15 @@ Development version: ::
 Usage
 -----
 
-**Important** Please note that from version 1.0.1 Flower supports Celery 5.
-This is a non-backwards compatible change, same as Celery 5 is not backwards compatible with the previous way of using
-their commands.
-
-With this comes the new way of launching
-`celery command with a subcommand <https://docs.celeryproject.org/en/stable/reference/cli.html#celery>`_
+**Important** Please note that from version 1.0.1 Flower uses Celery 5 and has to be invoked in the same style as celery
+commands do.
 
 The key takeaway here is that the Celery app's arguments have to be specified after the `celery` command and Flower's
 arguments have to be specified after the `flower` sub-command.
 
 This is the template to follow::
 
-    celery [OPTIONS] COMMAND [ARGS]
+    celery [celery args] flower [flower args]
 
 Core Celery args that you may want to set::
 
@@ -77,13 +73,20 @@ Core Celery args that you may want to set::
     -b, --broker
     --result-backend
 
-Launch the flower server at specified port other than default 5555 (open http://localhost:5566): ::
+More info on available `Celery command args <https://docs.celeryproject.org/en/stable/reference/cli.html#celery>`_.
+
+For Flower command args `see here <https://flower.readthedocs.io/en/latest/config.html#options>`_.
+
+Usage Examples
+--------------
+
+Launch the Flower server at specified port other than default 5555 (open the UI at http://localhost:5566): ::
 
     $ celery flower --port=5566
 
-Specify address and port for Flower: ::
+Specify Celery application path with address and port for Flower: ::
 
-    $ celery -A proj flower  --address=127.0.0.1 --port=5555
+    $ celery -A 'tasks' flower  --address=127.0.0.6 --port=5566
 
 Launch using docker: ::
 
@@ -93,9 +96,10 @@ Launch with unix socket file: ::
 
     $ celery flower --unix-socket=/tmp/flower.sock
 
-Broker URL and other configuration options can be passed through the standard Celery options (notice that they are after celery command and before flower sub-command: ::
+Broker URL and other configuration options can be passed through the standard Celery options (notice that they are after
+Celery command and before Flower sub-command): ::
 
-    $ celery -A proj --broker=amqp://guest:guest@localhost:5672// flower
+    $ celery --broker=amqp://guest:guest@localhost:5672// flower
 
 API
 ---

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -5,7 +5,7 @@ Configuration
 
 Flower can be configured from the command line: ::
 
-    $ flower --auto_refresh=False
+    $ celery flower --auto_refresh=False
 
 Using :file:`flowerconfig.py` configuration file:
 
@@ -26,7 +26,7 @@ Options passed through the command line have precedence over the options
 defined in the configuration file. The configuration file name and path
 can be changed with `conf`_ option. ::
 
-    $ flower --conf=celeryconfig.py
+    $ celery flower --conf=celeryconfig.py
 
 Options
 -------
@@ -40,7 +40,7 @@ the available settings, and their default values.
 Celery command line options also can be passed to Flower. For example
 the `--broker` sets the default broker URL: ::
 
-    $ flower -A proj --broker=amqp://guest:guest@localhost:5672//
+    $ celery -A proj --broker=amqp://guest:guest@localhost:5672// flower
 
 For a full list of options see: ::
 
@@ -90,7 +90,7 @@ broker_api
 Flower uses `RabbitMQ Management Plugin`_ to get info about queues.
 `broker_api` is a URL of RabbitMQ HTTP API including user credentials. ::
 
-    $ flower -A proj --broker_api=http://username:password@rabbitmq-server-name:15672/api/
+    $ celery -A proj flower --broker_api=http://username:password@rabbitmq-server-name:15672/api/
 
 .. Note:: By default the management plugin is not enabled. To enable it run::
 
@@ -276,7 +276,7 @@ Enables deploying Flower on non-root URL
 
 For example to access Flower on http://example.com/flower run it with: ::
 
-    $ flower --url_prefix=flower
+    $ celery flower --url_prefix=flower
 
 NOTE: The old `nginx` rewrite is no longer needed
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,15 +12,47 @@ Development version can be installed with ::
 Usage
 -----
 
-Launch the server and open http://localhost:5555 ::
+**Important** Please note that from version 1.0.1 Flower uses Celery 5 and has to be invoked in the same style as celery
+commands do.
 
-    $ flower -A proj --port=5555
+The key takeaway here is that the Celery app's arguments have to be specified after the `celery` command and Flower's
+arguments have to be specified after the `flower` sub-command.
 
-Or, launch from Celery ::
+This is the template to follow::
 
-    $ celery -A proj flower --address=127.0.0.1 --port=5555
+    celery [celery args] flower [flower args]
 
-Broker URL and other configuration options can be passed through the standard Celery options ::
+Core Celery args that you may want to set::
 
-    $ celery -A proj flower --broker=amqp://guest:guest@localhost:5672// --broker_api=http://guest:guest@localhost:15672/api/
+    -A, --app
+    -b, --broker
+    --result-backend
+
+More info on available `Celery command args <https://docs.celeryproject.org/en/stable/reference/cli.html#celery>`_.
+
+For Flower command args `see here <https://flower.readthedocs.io/en/latest/config.html#options>`_.
+
+Usage Examples
+--------------
+
+Launch the Flower server at specified port other than default 5555 (open the UI at http://localhost:5566): ::
+
+    $ celery flower --port=5566
+
+Specify Celery application path with address and port for Flower: ::
+
+    $ celery -A 'tasks' flower  --address=127.0.0.6 --port=5566
+
+Launch using docker: ::
+
+    $ docker run -p 5555:5555 mher/flower
+
+Launch with unix socket file: ::
+
+    $ celery flower --unix-socket=/tmp/flower.sock
+
+Broker URL and other configuration options can be passed through the standard Celery options (notice that they are after
+Celery command and before Flower sub-command): ::
+
+    $ celery --broker=amqp://guest:guest@localhost:5672// flower
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,7 +41,7 @@ Launch the Flower server at specified port other than default 5555 (open the UI 
 
 Specify Celery application path with address and port for Flower: ::
 
-    $ celery -A 'tasks' flower  --address=127.0.0.6 --port=5566
+    $ celery -A proj flower  --address=127.0.0.6 --port=5566
 
 Launch using docker: ::
 

--- a/docs/man.rst
+++ b/docs/man.rst
@@ -47,24 +47,38 @@ OPTIONS
 
   --address                        run on the given address
   --auth                           regexp  of emails to grant access
+  --auth_provider                  sets authentication provider class
+  --auto_refresh                   refresh dashboard automatically (default *True*)
   --basic_auth                     colon separated user-password to enable
                                    basic auth
   --broker_api                     inspect broker e.g.
                                    http://guest:guest@localhost:15672/api/
+  --ca_certs                       path to SSL certificate authority (CA) file
   --certfile                       path to SSL certificate file
+  --conf                           flower configuration file path (default *flowerconfig.py*)
+  --cookie_secret                  secure cookie secret
   --db                             flower database file (default *flower.db*)
   --debug                          run in debug mode (default *False*)
+  --enable_events                  periodically enable Celery events (default *True*)
+  --format_task                    use custom task formatter
   --help                           show this help information
   --inspect                        inspect workers (default *True*)
   --inspect_timeout                inspect timeout (in milliseconds) (default
                                    *1000*)
   --keyfile                        path to SSL key file
-  --max_workrs                     maximum number of workers to keep in memory
+  --max_workers                     maximum number of workers to keep in memory
                                    (default *5000*)
   --max_tasks                      maximum number of tasks to keep in memory
                                    (default *10000*)
+  --natural_time                   show time in relative format (default *False*)
   --persistent                     enable persistent mode (default *False*)
   --port                           run on the given port (default *5555*)
+  --purge_offline_workers          time (in seconds) after which offline workers are purged
+                                   from dashboard
+  --state_save_interval            state save interval (in milliseconds) (default *0*)
+  --tasks_columns                  slugs of columns on /tasks/ page, delimited by comma
+                                   (default *name,uuid,state,args,kwargs,result,received,started,runtime,worker*)
+  --unix_socket                    path to unix socket to bind flower server to
   --url_prefix                     base url prefix
   --xheaders                       enable support for the 'X-Real-Ip' and
                                    'X-Scheme' headers. (default *False*)
@@ -91,14 +105,15 @@ TORNADO OPTIONS
 USAGE
 =====
 
-Launch the server and open http://localhost:5555: ::
+Launch the Flower server at specified port other than default 5555 (open the UI at http://localhost:5566): ::
 
-    $ flower -A proj --port=5555
+    $ celery flower --port=5566
 
-Or, launch from Celery: ::
+Specify Celery application path with address and port for Flower: ::
 
-    $ celery flower -A proj --address=127.0.0.1 --port=5555
+    $ celery -A proj flower --address=127.0.0.6 --port=5566
 
-Broker URL and other configuration options can be passed through the standard Celery options: ::
+Broker URL and other configuration options can be passed through the standard Celery options (notice that they are after
+Celery command and before Flower sub-command): ::
 
-    $ celery flower -A proj --broker=amqp://guest:guest@localhost:5672//
+    $ celery -A proj --broker=amqp://guest:guest@localhost:5672// flower

--- a/flower/command.py
+++ b/flower/command.py
@@ -86,20 +86,21 @@ def apply_options(prog_name, argv):
 
 
 def warn_about_celery_args_used_in_flower_command(ctx, flower_args):
-    celery_args = [option for param in ctx.parent.command.params for option in param.opts]
+    celery_options = [option for param in ctx.parent.command.params for option in param.opts]
 
     incorrectly_used_args = []
     for arg in flower_args:
         arg_name, _, _ = arg.partition("=")
-        if arg_name in celery_args:
+        if arg_name in celery_options:
             incorrectly_used_args.append(arg_name)
 
-    logger.warning(
-        f'You have incorrectly specified the following celery arguments after flower command:'
-        f' {incorrectly_used_args}. '
-        f'Please specify them after celery command instead following this template: '
-        f'celery [celery args] flower [flower args].'
-    )
+    if incorrectly_used_args:
+        logger.warning(
+            f'You have incorrectly specified the following celery arguments after flower command:'
+            f' {incorrectly_used_args}. '
+            f'Please specify them after celery command instead following this template: '
+            f'celery [celery args] flower [flower args].'
+        )
 
 
 def setup_logging():

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,6 @@ setup(
     package_data={'flower': ['templates/*', 'static/*.*',
                              'static/**/*.*', 'static/**/**/*.*']},
     entry_points={
-        'console_scripts': [
-            'flower = flower.__main__:main',
-        ],
         'celery.commands': [
             'flower = flower.command:flower',
         ],

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -54,7 +54,7 @@ class TestWarnAboutCeleryArgsUsedInFlowerCommand(AsyncHTTPTestCase):
         )
 
         mock_warning.assert_called_once_with(
-            "You have incorrectly specified the following celery args after flower command: "
+            "You have incorrectly specified the following celery arguments after flower command: "
             "[\'--app\', \'-b\']. Please specify them after celery command instead following"
             " this template: celery [celery args] flower [flower args]."
         )


### PR DESCRIPTION
A lot of doc updates removing any instructions showing usage of Flower as `flower [args]`.
Users should now always use `celery [celery args] flower [flower args] as per Celery 5 instructions.

Removed flower command line alias from `setup.py`.
Add a warning when instantiating Flower if user specified celery args in the flower part.
