### PR TITLE
Fix: Flower DB getting filled very quickly

### DIFF
--- a/flower/events.py
+++ b/flower/events.py
@@ -174,7 +174,7 @@ class Events(threading.Thread):
 
     def save_state(self):
         logger.debug("Saving state to '%s'...", self.db)
-        state = shelve.open(self.db)
+        state = shelve.open(self.db, flag='n')
         state['events'] = self.state
         state.close()
 


### PR DESCRIPTION
Fix https://github.com/mher/flower/issues/1075

I test it with state_save_interval=5000 

if flower calls Events.save_state while Updating Events.state with new tasks it make db files broken. 
Normal .dir file 
```
cat .dir
'events', (0, 3680170)
```

Broken .dir file
```
cat .dir
'events', (25347584, 3661188)

```
And size gets huge
```
drwxr-xr-x  2 nelson nelson 4.0K May 25 13:13 .
drwxr-xr-x 12 nelson nelson 4.0K May 25 13:04 ..
-rw-r--r--  1 nelson nelson   27 May 25 13:13 .bak
-rw-r--r--  1 nelson nelson 559K May 25 13:13 .dat
-rw-r--r--  1 nelson nelson   27 May 25 13:13 .dir
```

after 1000 tasks

```
drwxr-xr-x  2 nelson nelson  4.0K May 25 13:14 .
drwxr-xr-x 12 nelson nelson  4.0K May 25 13:04 ..
-rw-r--r--  1 nelson nelson    27 May 25 13:14 .bak
-rw-r--r--  1 nelson nelson 1003K May 25 13:14 .dat
-rw-r--r--  1 nelson nelson    27 May 25 13:14 .dir
```

after 10000 tasks

```
drwxr-xr-x  2 nelson nelson 4.0K May 25 13:16 .
drwxr-xr-x 12 nelson nelson 4.0K May 25 13:04 ..
-rw-r--r--  1 nelson nelson   30 May 25 13:16 .bak
-rw-r--r--  1 nelson nelson  47M May 25 13:16 .dat
-rw-r--r--  1 nelson nelson   30 May 25 13:16 .dir
```

When the max_tasks_in_memory threshold (default 10000) is reached, the file still grows

```
drwxr-xr-x  2 nelson nelson 4.0K May 25 13:16 .
drwxr-xr-x 12 nelson nelson 4.0K May 25 13:04 ..
-rw-r--r--  1 nelson nelson   30 May 25 13:16 .bak
-rw-r--r--  1 nelson nelson  50M May 25 13:16 .dat
-rw-r--r--  1 nelson nelson   30 May 25 13:16 .dir
```

**Fix** 
Re-create a shelve file every time a state saving
