### PR TITLE
Add purge_offline_workers option to configuration docs

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -222,6 +222,13 @@ port
 
 Run the http server on a given port (by default, `port=5555`)
 
+.. _purge_offline_workers:
+
+purge_offline_workers
+~~~~~~~~~~~~~~~~~~~~~
+
+Time (in seconds) after which offline workers are purged from dashboard
+
 .. _state_save_interval:
 
 state_save_interval

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -117,7 +117,7 @@ class TestConfOption(AsyncHTTPTestCase):
             return int(subprocess.check_output(
                 'grep "%s" %s|wc -l' % (patter, filename), shell=True))
 
-        defined = grep('^define(', 'flower/options.py') - 4
+        defined = grep('^define(', 'flower/options.py') - 3
         documented = grep('^~~', 'docs/config.rst')
         self.assertEqual(defined, documented,
                          msg='Missing option documentation. Make sure all options '


### PR DESCRIPTION
I've found `purge_offline_workers` in the code but it was not in the documentation.