### PR TITLE
Fix Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ USER flower
 
 VOLUME $FLOWER_DATA_DIR
 
-CMD ["celery flower"]
+CMD ["celery", "flower"]


### PR DESCRIPTION
The dockerfile CMD was not working because it was treating the "celery flower" as a single command