### PR TITLE
Disable authentication of /metrics endpoint.

### DIFF
--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -6,6 +6,11 @@ Protecting your Flower instance from unwarranted access is important
 if it runs in an untrusted environment. Below, we outline the various
 forms of authentication supported by Flower.
 
+**NOTE:** The following endpoints are exempt from authentication:
+
+- /healthcheck
+- /metrics
+
 .. _basic-auth:
 
 HTTP Basic Authentication

--- a/flower/views/monitor.py
+++ b/flower/views/monitor.py
@@ -1,20 +1,18 @@
 import prometheus_client
 
-from tornado import web
 from tornado import gen
 
 from ..views import BaseHandler
 
 
 class Metrics(BaseHandler):
-    @web.authenticated
     @gen.coroutine
     def get(self):
         self.write(prometheus_client.generate_latest())
         self.set_header("Content-Type", "text/plain")
 
+
 class Healthcheck(BaseHandler):
     @gen.coroutine
     def get(self):
         self.write("OK")
-        


### PR DESCRIPTION
Hi @mher ,

Disable authentication of `/metrics` endpoint in a simplest way by removing `@web.authenticated` decorator from the get method as per our chat on the issue #1066.

Add docs in `auth.rst` listing endpoints with disabled authentication.
Let me know if anything else is missing on this one.

