### PR TITLE
Add links for children jobs

### DIFF
--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -79,6 +79,11 @@
                     {% elif name in ['parent_id', 'root_id'] %}
                     <a
                         href="{{ reverse_url('task', getattr(task, name, None)) }}">{{ getattr(task, name, None) }}</a>
+                    {% elif name == 'children' %}
+                      {% for child in getattr(task, name, {}) %}
+                        <a href="{{ reverse_url('task', child.id) }}">{{ child.id }}</a>
+                        <br>
+                      {% end %}
                     {% else %}
                       {{ getattr(task, name, None) }}
                     {% end %}


### PR DESCRIPTION
It would be better to have a URL for children. These "weakref" objects are not useable.