### PR TITLE
sort tasks by started desc by default and fixing doc

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -326,7 +326,7 @@ Sets task runtime latency buckets
 
 buckets value can be provided as cli options: ::
 
-    $ celery flower task_runtime_metric_buckets=1,5,10,inf
+    $ celery flower --task_runtime_metric_buckets=1,5,10,inf
 
 Or, it can be also provided as ENV variable: ::
 

--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -541,7 +541,7 @@ var flower = (function () {
                 url: url_prefix() + '/tasks/datatable'
             },
             order: [
-                [7, "asc"]
+                [7, "desc"]
             ],
             oSearch: {
                 "sSearch": $.urlParam('state') ? 'state:' + $.urlParam('state') : ''


### PR DESCRIPTION
this PR has below changes:
1. show the recent task on top in tasks page
2. fixing doc