### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/tests/unit/views/test_monitor.py
+++ b/tests/unit/views/test_monitor.py
@@ -208,4 +208,4 @@ class HealthcheckTests(AsyncHTTPTestCase):
 
     def test_healthcheck_route(self):
         response = self.get('/healthcheck').body.decode('utf-8')
-        self.assertEquals(response, 'OK')
+        self.assertEqual(response, 'OK')


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268