### PR TITLE
Fix master build failing caused by newest humanize package missing VERSION attribute 

### DIFF
--- a/flower/utils/__init__.py
+++ b/flower/utils/__init__.py
@@ -20,11 +20,11 @@ def bugreport(app=None):
         return 'flower   -> flower:%s tornado:%s humanize:%s%s' % (
             __version__,
             tornado.version,
-            humanize.VERSION,
+            humanize.__version__,
             app.bugreport()
         )
-    except (ImportError, AttributeError):
-        return 'Unknown Celery version'
+    except (ImportError, AttributeError) as e:
+        return f"Error when generating bug report: {e}. Have you installed correct versions of Flower's dependencies?"
 
 
 def abs_path(path):

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 celery>=5.0.5
 tornado>=5.0.0,<7.0.0
 prometheus_client>=0.8.0
-humanize
+humanize==3.12.0
 pytz

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock
 
 from flower.utils import bugreport
 from celery import Celery
@@ -7,7 +8,7 @@ from celery import Celery
 class BugreportTests(unittest.TestCase):
     def test_default(self):
         report = bugreport()
-        self.assertFalse('Unknown Celery version' in report)
+        self.assertFalse('Error when generating bug report' in report)
         self.assertTrue('tornado' in report)
         self.assertTrue('humanize' in report)
         self.assertTrue('celery' in report)
@@ -15,7 +16,15 @@ class BugreportTests(unittest.TestCase):
     def test_with_app(self):
         app = Celery()
         report = bugreport(app)
-        self.assertFalse('Unknown Celery version' in report)
+        self.assertFalse('Error when generating bug report' in report)
         self.assertTrue('tornado' in report)
         self.assertTrue('humanize' in report)
         self.assertTrue('celery' in report)
+
+    def test_when_unable_to_generate_report(self):
+        fake_app = Mock()
+        fake_app.bugreport.side_effect = ImportError('import error message')
+        report = bugreport(fake_app)
+        self.assertTrue('Error when generating bug report' in report)
+        self.assertTrue('import error message' in report)
+        self.assertTrue("Have you installed correct versions of Flower's dependencies?" in report)


### PR DESCRIPTION
When accessing humanize.VERSION we were running into an attribute error since they removed VERSION from that file.
We are supposed to use the standard `__version__` now.

Also set humanize package version in stone.
Modify message from bugreport function.
Add test confirming new bugreport behaviour.