### PR TITLE
Remove deprecated alias.

### DIFF
--- a/tests/unit/views/test_monitor.py
+++ b/tests/unit/views/test_monitor.py
@@ -208,4 +208,4 @@ class HealthcheckTests(AsyncHTTPTestCase):
 
     def test_healthcheck_route(self):
         response = self.get('/healthcheck').body.decode('utf-8')
-        self.assertEquals(response, 'OK')
+        self.assertEqual(response, 'OK')


### PR DESCRIPTION
I noticed this when running `tox`.  Should be OK to remove since you specify your minimum target Python version as 3.6.