### PR TITLE
add url_prefix to Visit me at banner

### DIFF
--- a/flower/command.py
+++ b/flower/command.py
@@ -149,9 +149,15 @@ def is_flower_envvar(name):
 
 def print_banner(app, ssl):
     if not options.unix_socket:
+        if options.url_prefix:
+            prefix_str = f'/{options.url_prefix}/'
+        else:
+            prefix_str = ''
+
         logger.info(
-            "Visit me at http%s://%s:%s", 's' if ssl else '',
-            options.address or 'localhost', options.port
+            "Visit me at http%s://%s:%s%s", 's' if ssl else '',
+            options.address or 'localhost', options.port,
+            prefix_str
         )
     else:
         logger.info("Visit me via unix socket file: %s", options.unix_socket)


### PR DESCRIPTION
Previously the banner message only showed localhost, even if a `--url-prefix` was set, so clicking on this linked caused a `404´.
```console
(venv) ubu@ububox:~/workspace/flower$ celery flower
[I 220123 18:04:13 command:157] Visit me at http://localhost:5555
[I 220123 18:04:13 command:165] Broker: amqp://guest:**@queue:5672//
[I 220123 18:04:13 command:166] Registered tasks: 
```

Now it also displays the url prefix in the banner when running `celery flower --ulr-prefix=flower`: 
```console
(venv) ubu@ububox:~/workspace/flower$ celery flower
[I 220123 18:06:18 command:157] Visit me at http://localhost:5555/flower/
[I 220123 18:06:18 command:165] Broker: amqp://guest:**@queue:5672//
[I 220123 18:06:18 command:166] Registered tasks: 
```