### PR TITLE
API Change: Feature - Delete Tasks

### DIFF
--- a/flower/events.py
+++ b/flower/events.py
@@ -207,6 +207,22 @@ class Events(threading.Thread):
                 logger.debug(e, exc_info=True)
                 time.sleep(try_interval)
 
+    def delete_tasks_by_time(self, to_timestamp):
+        state = shelve.open(self.db, flag='n')
+        state['events'] = self.state
+        for uuid, task in enumerate(state.tasks_by_time()):
+            # if date is less than <filter_date> delete tasks
+            if task.timestamp <= to_timestamp:
+                del state['events']['tasks'][uuid]
+        state.close()
+
+    def delete_all_tasks(self):
+        state = shelve.open(self.db, flag='n')
+        state['events'] = self.state
+        for uuid, task in enumerate(state.tasks_by_time()):
+            del state['events']['tasks'][uuid]
+        state.close()
+
     def save_state(self):
         logger.debug("Saving state to '%s'...", self.db)
         state = shelve.open(self.db, flag='n')


### PR DESCRIPTION
Example: Delete tasks older than 48hours

```python
import celery
import os
import timedelta
import datetime

broker = os.environ.get('CELERY_BROKER_URL')
app = celery.Celery('tasks', broker=broker)
flower = Flower(capp=app, options=flower_options)

time_delta = timedelta(hours=48)
now = datetime.datetime.now()
delete_before_time = now-time_delta

flower.events.delete_tasks_by_time(delete_before_time.timestamp())
```