### PR TITLE
Celery docs update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Core Celery args that you may want to set::
     -b, --broker
     --result-backend
 
-More info on available `Celery command args <https://docs.celeryproject.org/en/stable/reference/cli.html#celery>`_.
+More info on available `Celery command args <https://docs.celeryq.dev/en/stable/reference/cli.html#celery>`_.
 
 For Flower command args `see here <https://flower.readthedocs.io/en/latest/config.html#options>`_.
 

--- a/docs/api.ipynb
+++ b/docs/api.ipynb
@@ -283,7 +283,7 @@
    "metadata": {},
    "source": [
     "## rate-limit\n",
-    "Update [rate limit](http://docs.celeryproject.org/en/latest/userguide/tasks.html#Task.rate_limit) for a task."
+    "Update [rate limit](https://docs.celeryq.dev/en/latest/userguide/tasks.html#Task.rate_limit) for a task."
    ]
   },
   {
@@ -324,7 +324,7 @@
    "metadata": {},
    "source": [
     "## timeout\n",
-    "Set timeout (both [hard](http://docs.celeryproject.org/en/latest/userguide/tasks.html#Task.time_limit) and [soft](http://docs.celeryproject.org/en/latest/userguide/tasks.html#Task.soft_time_limit)) for a task."
+    "Set timeout (both [hard](https://docs.celeryq.dev/en/latest/userguide/tasks.html#Task.time_limit) and [soft](https://docs.celeryq.dev/en/latest/userguide/tasks.html#Task.soft_time_limit)) for a task."
    ]
   },
   {
@@ -470,7 +470,7 @@
    "metadata": {},
    "source": [
     "## pool/restart\n",
-    "Restart a worker pool, you need to have [CELERYD_POOL_RESTARTS](http://docs.celeryproject.org/en/latest/configuration.html#std:setting-CELERYD_POOL_RESTARTS) enabled in your configuration)."
+    "Restart a worker pool, you need to have [CELERYD_POOL_RESTARTS](https://docs.celeryq.dev/en/latest/configuration.html#std:setting-CELERYD_POOL_RESTARTS) enabled in your configuration)."
    ]
   },
   {
@@ -591,7 +591,7 @@
    "metadata": {},
    "source": [
     "## pool/autoscale\n",
-    "[Autoscale](http://docs.celeryproject.org/en/latest/userguide/workers.html#autoscaling) a pool."
+    "[Autoscale](https://docs.celeryq.dev/en/latest/userguide/workers.html#autoscaling) a pool."
    ]
   },
   {
@@ -631,7 +631,7 @@
    "metadata": {},
    "source": [
     "## queue/add-consumer\n",
-    "[Add a consumer](http://docs.celeryproject.org/en/latest/userguide/workers.html#std:control-add_consumer) to a queue."
+    "[Add a consumer](https://docs.celeryq.dev/en/latest/userguide/workers.html#std:control-add_consumer) to a queue."
    ]
   },
   {
@@ -672,7 +672,7 @@
    "metadata": {},
    "source": [
     "## queue/cancel-consumer\n",
-    "[Cancel a consumer](http://docs.celeryproject.org/en/latest/userguide/workers.html#queues-cancelling-consumers) queue."
+    "[Cancel a consumer](https://docs.celeryq.dev/en/latest/userguide/workers.html#queues-cancelling-consumers) queue."
    ]
   },
   {

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -35,7 +35,7 @@ Standard Celery configuration settings can be overridden in the configuration
 file. See `Celery Configuration reference`_ for a complete listing of all
 the available settings, and their default values.
 
-.. _`Celery Configuration reference`: http://docs.celeryproject.org/en/latest/userguide/configuration.html
+.. _`Celery Configuration reference`: https://docs.celeryq.dev/en/latest/userguide/configuration.html
 
 Celery command line options also can be passed to Flower. For example
 the `--broker` sets the default broker URL: ::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Flower - Celery monitoring tool
 
 Flower is a web based tool for monitoring and administrating `Celery`_ clusters
 
-.. _Celery: https://docs.celeryproject.org/en/stable/#
+.. _Celery: https://docs.celeryq.dev/en/stable/#
 
 .. include:: features.rst
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -28,7 +28,7 @@ Core Celery args that you may want to set::
     -b, --broker
     --result-backend
 
-More info on available `Celery command args <https://docs.celeryproject.org/en/stable/reference/cli.html#celery>`_.
+More info on available `Celery command args <https://docs.celeryq.dev/en/stable/reference/cli.html#celery>`_.
 
 For Flower command args `see here <https://flower.readthedocs.io/en/latest/config.html#options>`_.
 

--- a/docs/prometheus-integration.rst
+++ b/docs/prometheus-integration.rst
@@ -77,7 +77,7 @@ We have the following labels available:
 
 * **task** - task name, i.e. ``tasks.add``, ``tasks.multiply``.
 * **type** - task event type, i.e. ``task-started``, ``task-succeeded``. Note that worker related events **will not be counted**.
-  For more info on task event types see: `task events in celery <https://docs.celeryproject.org/en/stable/userguide/monitoring.html#task-events>`_.
+  For more info on task event types see: `task events in celery <https://docs.celeryq.dev/en/stable/userguide/monitoring.html#task-events>`_.
 * **worker** - celery worker name, i.e ``celery@<your computer name>``.
 
 Example Prometheus Alerts

--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -336,7 +336,7 @@
                 {% for name,value in sorted(worker.get('conf', {}).items()) %}
                     {% if value is not None %}
                       <tr>
-                        <td><a href="http://docs.celeryproject.org/en/latest/userguide/configuration.html#{{ name.lower().replace('_', '-') }}" target="_blank">{{ name }}</a></td>
+                        <td><a href="https://docs.celeryq.dev/en/latest/userguide/configuration.html#{{ name.lower().replace('_', '-') }}" target="_blank">{{ name }}</a></td>
                         <td>{{ value }}</td>
                       </tr>
                     {% end %}


### PR DESCRIPTION
Old website is not working anymore: https://docs.celeryproject.org/
Use new URL https://docs.celeryq.dev instead

See https://github.com/celery/celery main repo.