### PR TITLE
Fixing `CORS` support 

### DIFF
--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -17,7 +17,8 @@ logger = logging.getLogger(__name__)
 class BaseHandler(tornado.web.RequestHandler):
     def set_default_headers(self):
         self.set_header("Access-Control-Allow-Origin", "*")
-        self.set_header("Access-Control-Allow-Headers", "x-requested-with")
+        self.set_header("Access-Control-Allow-Headers",
+                        "x-requested-with,access-control-allow-origin,authorization,content-type")
         self.set_header('Access-Control-Allow-Methods',
                         ' PUT, DELETE, OPTIONS, POST, GET, PATCH')
 

--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -19,7 +19,7 @@ class BaseHandler(tornado.web.RequestHandler):
         self.set_header("Access-Control-Allow-Origin", "*")
         self.set_header("Access-Control-Allow-Headers", "x-requested-with")
         self.set_header('Access-Control-Allow-Methods',
-                        ' PUT, DELETE, OPTIONS')
+                        ' PUT, DELETE, OPTIONS, POST, GET, PATCH')
 
     def options(self, *args, **kwargs):
         self.set_status(204)

--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -21,7 +21,7 @@ class BaseHandler(tornado.web.RequestHandler):
         self.set_header('Access-Control-Allow-Methods',
                         ' PUT, DELETE, OPTIONS')
 
-    def options(self):
+    def options(self, *args, **kwargs):
         self.set_status(204)
         self.finish()
 


### PR DESCRIPTION
### What?

- Allow `POST`, `GET` and `PATH` Methods 
- Allow `access-control-allow-origin,authorization,content-type` Headers
- Added `*args` and `*kwargs` to `def options(self)` signature

Why?
- being able to send those methods to a basic authenticated flower instance 
- allow sending the Authorization headers with the base-64 encoded user and password as well as other frequently used headers such as Content-Type
- prevent and fix #1199 to happen according to tornado [documentation](https://www.tornadoweb.org/en/stable/web.html?highlight=RequestHandler#tornado.web.RequestHandler.options) 