### PR TITLE
Encode worker and task names in URL

### DIFF
--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -468,7 +468,7 @@ var flower = (function () {
                 data: 'hostname',
                 type: 'natural',
                 render: function (data, type, full, meta) {
-                    return '<a href="' + url_prefix() + '/worker/' + data + '">' + data + '</a>';
+                    return '<a href="' + url_prefix() + '/worker/' + encodeURIComponent(data) + '">' + data + '</a>';
                 }
             }, {
                 targets: 1,
@@ -559,7 +559,7 @@ var flower = (function () {
                 visible: isColumnVisible('uuid'),
                 orderable: false,
                 render: function (data, type, full, meta) {
-                    return '<a href="' + url_prefix() + '/task/' + data + '">' + data + '</a>';
+                    return '<a href="' + url_prefix() + '/task/' + encodeURIComponent(data) + '">' + data + '</a>';
                 }
             }, {
                 targets: 2,
@@ -623,7 +623,7 @@ var flower = (function () {
                 data: 'worker',
                 visible: isColumnVisible('worker'),
                 render: function (data, type, full, meta) {
-                    return '<a href="' + url_prefix() + '/worker/' + data + '">' + data + '</a>';
+                    return '<a href="' + url_prefix() + '/worker/' + encodeURIComponent(data) + '">' + data + '</a>';
                 }
             }, {
                 targets: 10,


### PR DESCRIPTION
This addresses a bug where worker or task names that contain characters that should be URL encoded cannot be navigated to in the UI.

We are seeing this issue with workers named `celery@foo.bar` when browsing the UI with Firefox. If the `@` is encoded to `%40` the link works.