### PR TITLE
The old templates are not consistent with newer versions of Django wh…

### DIFF
--- a/flower/templates/404.html
+++ b/flower/templates/404.html
@@ -7,7 +7,7 @@
                 {{ message }}
             {% else %}
                 Error, page not found
-            {% end %}
+            {% endif %}
         </p>
     </div>
-{% end %}
+{% endblock %}

--- a/flower/templates/base.html
+++ b/flower/templates/base.html
@@ -24,7 +24,7 @@
     <link href="{{ static_url('css/jquery.dataTables.css') }}" rel="stylesheet">
 
     {% block extra_styles %}
-    {% end %}
+    {% endblock %}
 
     <!--[if lt IE 9]>
       <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
@@ -41,7 +41,7 @@
   <body>
     {% block navbar %}
         {% module Template("navbar.html", active_tab="") %}
-    {% end %}
+    {% endblock %}
 
     <div class="container-fluid">
       <div id="alert" class="alert alert-success hide">
@@ -52,7 +52,7 @@
     </div>
 
     {% block container %}
-    {% end %}
+    {% endblock %}
 
     <!-- Le javascript
     ================================================== -->
@@ -85,7 +85,7 @@
     <script src="{{ static_url('js/flower.js') }}"></script>
 
     {% block extra_scripts %}
-    {% end %}
+    {% endblock %}
 
   </body>
 </html>

--- a/flower/templates/broker.html
+++ b/flower/templates/broker.html
@@ -2,7 +2,7 @@
 
 {% block navbar %}
   {% module Template("navbar.html", active_tab="broker") %}
-{% end %}
+{% endblock %}
 
 {% block container %}
   <div class="container-fluid">
@@ -32,9 +32,9 @@
             <td>{{ queue.get('consumers', 'N/A') }}</td>
             <td>{{ queue.get('idle_since', 'N/A') }}</td>
         </tr>
-      {% end %}
+      {% endfor %}
       </tbody>
      </table>
 
 </div>
-{% end %}
+{% endblock %}

--- a/flower/templates/dashboard.html
+++ b/flower/templates/dashboard.html
@@ -2,7 +2,7 @@
 
 {% block navbar %}
   {% module Template("navbar.html", active_tab="dashboard")%}
-{% end %}
+{% endblock %}
 
 {% block container %}
   <div class="container-fluid">
@@ -42,17 +42,17 @@
             <td>{{ info.get('task-retried', 0) }}</td>
             <td>{{ humanize(info.get('loadavg', 'N/A')) }}</td>
         </tr>
-        {% end %}
+        {% endfor %}
       </tbody>
     </table>
 
         </div>
     </div>
 
-{% end %}
+{% endblock %}
 
 {% block extra_scripts %}
 <script type="text/javascript">
   var autorefresh = {{ autorefresh }};
 </script>
-{% end %}
+{% endblock %}

--- a/flower/templates/error.html
+++ b/flower/templates/error.html
@@ -2,19 +2,19 @@
 
 {% block container %}
     {% if debug %}
-    <div class="span12">
-        <p>It looks like you have found a bug! You can help to improve
-        Flower by opening an issue in <a href="https://github.com/mher/flower/issues">https://github.com/mher/flower/issues</a>
-        </p>
-        <pre>
-{{ bugreport }}
+        <div class="span12">
+            <p>It looks like you have found a bug! You can help to improve
+            Flower by opening an issue in <a href="https://github.com/mher/flower/issues">https://github.com/mher/flower/issues</a>
+            </p>
+            <pre>
+                {{ bugreport }}
 
-{{ error_trace }}
-        </pre>
-    </div>
+                {{ error_trace }}
+            </pre>
+        </div>
     {% else %}
-    <div class="span12">
-        Error {{ status_code }}
-    </div>
-    {% end %}
-{% end %}
+        <div class="span12">
+            Error {{ status_code }}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -2,7 +2,7 @@
 
 {% block navbar %}
   {% module Template("navbar.html", active_tab="tasks") %}
-{% end %}
+{% endblock %}
 
 {% block container %}
   <div id='task-page' class="container-fluid">
@@ -16,7 +16,7 @@
                 <button style="float: right" class="btn btn-danger" onclick="flower.on_task_terminate(event)">Terminate</button>
             {% elif task.state == "RECEIVED" or task.state == "RETRY" %}
                 <button  style="float: right" class="btn btn-danger" onclick="flower.on_task_revoke(event)">Revoke</button>
-            {% end %}
+            {% endif %}
           </h2>
         </div>
         <div class="row-fluid">
@@ -41,7 +41,7 @@
                   <span class="label label-important">{{ task.state }}</span>
                   {% else %}
                   <span class="label label-default">{{ task.state }}</span>
-                  {% end %}
+                  {% endif %}
                 </td>
               </tr>
               <tr>
@@ -83,14 +83,14 @@
                       {% for child in getattr(task, name, {}) %}
                         <a href="{{ reverse_url('task', child.id) }}">{{ child.id }}</a>
                         <br>
-                      {% end %}
+                      {% endfor %}
                     {% else %}
                       {{ getattr(task, name, None) }}
-                    {% end %}
+                    {% endif %}
                   </td>
                 </tr>
-                {% end %}
-              {% end %}
+                {% endif %}
+              {% endfor %}
               </tbody>
             </table>
           </div>
@@ -98,4 +98,4 @@
       </div>
     </div>
   </div>
-{% end %}
+{% endblock %}

--- a/flower/templates/tasks.html
+++ b/flower/templates/tasks.html
@@ -2,7 +2,7 @@
 
 {% block navbar %}
   {% module Template("navbar.html", active_tab="tasks") %}
-{% end %}
+{% endblock %}
 
 
 {% block container %}
@@ -37,7 +37,7 @@
     {% for uuid, task in tasks %}
         {% if getattr(task, 'name', None) is None %}
             {% continue %}
-        {% end %}
+        {% endif %}
     <tr>
       <td>{{ task.name }}</td>
       <td>{{ task.uuid }}</td>
@@ -49,14 +49,14 @@
             {{ task.result }}
         {% elif task.state == "FAILURE" %}
             {{ task.exception }}
-        {% end %}
+        {% endif %}
       </td>
       <td>{{ humanize(task.received, type='time') }}</td>
       <td>{{ humanize(task.started, type='time') }}</td>
       <td>
         {% if task.timestamp and task.started %}
             {{ '%.2f' % humanize(task.timestamp - task.started) }} sec
-        {% end %}
+        {% endif %}
       </td>
       <td>{{ task.worker }}</td>
       <td>{{ task.exchange }}</td>
@@ -67,8 +67,8 @@
       <td>{{ task.expires }}</td>
       <td>{{ task.eta }}</td>
     </tr>
-      {% end %}
+      {% endfor %}
     </tbody>
   </table>
 </div>
-{% end %}
+{% endblock %}

--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -2,7 +2,7 @@
 
 {% block navbar %}
   {% module Template("navbar.html", active_tab="workers") %}
-{% end %}
+{% endblock %}
 
 {% block container %}
 
@@ -40,7 +40,7 @@
             <li><a href="#tab-system" data-toggle="tab">System</a></li>
             {% if other %}
             <li><a href="#tab-other" data-toggle="tab">Other</a></li>
-            {% end %}
+            {% endif %}
           </ul>
 
           <div class="tab-content">
@@ -56,7 +56,7 @@
                           <td>{{ humanize(name) }}</td>
                           <td>{{ humanize(value) }}</td>
                         </tr>
-                      {% end %}
+                      {% endfor %}
                         <tr>
                             <td>Worker PID</td>
                             <td>{{ worker['stats'].get('pid', 'N/A')}}</td>
@@ -116,12 +116,12 @@
                                 <td>{{ humanize(name) }}</td>
                                 <td>{{ humanize(value) }}</td>
                                 </tr>
-                            {% end %}
+                            {% endfor %}
                             </tbody>
                         </table>
                     </div>
                 </div>
-              {% end %}
+              {% endif %}
 
             </div> <!-- end pool tab -->
 
@@ -135,7 +135,7 @@
                         <td>{{ humanize(name) }}</td>
                         <td>{{ value }}</td>
                       </tr>
-                    {% end %}
+                    {% endfor %}
                   </tbody>
                 </table>
               </div>
@@ -184,7 +184,7 @@
                       <td>{{ queue['auto_delete'] }}</td>
                       <td><button class="btn btn-danger" onclick="flower.on_cancel_consumer(event)">Cancel Consumer</button></td>
                   </tr>
-                {% end %}
+                {% endfor %}
               </tbody>
               </table>
             </div> <!-- end queues tab -->
@@ -198,7 +198,7 @@
                       <td>{{ name }}</td>
                       <td>{{ value }}</td>
                     </tr>
-                  {% end %}
+                  {% endfor %}
                   </tbody>
               </table>
 
@@ -224,7 +224,7 @@
                       <td>{{ task.get('args', 'N/A') }}</td>
                       <td>{{ task.get('kwargs', 'N/A') }}</td>
                     </tr>
-                  {% end %}
+                  {% endfor %}
                 </tbody>
               </table>
 
@@ -246,7 +246,7 @@
                       <td>{{ task['request']['args'] }}</td>
                       <td>{{ task['request']['kwargs'] }}</td>
                     </tr>
-                  {% end %}
+                  {% endfor %}
                   </tbody>
               </table>
 
@@ -268,7 +268,7 @@
                       <td>{{ task['args'] }}</td>
                       <td>{{ task['kwargs'] }}</td>
                     </tr>
-                  {% end %}
+                  {% endfor %}
                   </tbody>
               </table>
 
@@ -284,7 +284,7 @@
                     <tr>
                       <td><a href="{{ reverse_url('task', task) }}">{{ task }}</a></td>
                     </tr>
-                  {% end %}
+                  {% endfor %}
                 </tbody>
               </table>
             </div> <!-- end tasks tab -->
@@ -324,7 +324,7 @@
                       </div>
                     </td>
                   </tr>
-                {% end %}
+                {% endfor %}
               </table>
           </div> <!-- end limits tab -->
 
@@ -339,8 +339,8 @@
                         <td><a href="http://docs.celeryproject.org/en/latest/userguide/configuration.html#{{ name.lower().replace('_', '-') }}" target="_blank">{{ name }}</a></td>
                         <td>{{ value }}</td>
                       </tr>
-                    {% end %}
-                  {% end %}
+                    {% endif %}
+                  {% endfor %}
                 </tbody>
               </table>
             </div>
@@ -357,8 +357,8 @@
                             <td>{{ name }}</td>
                             <td>{{ value }}</td>
                         </tr>
-                    {% end %}
-                {% end %}
+                    {% endfor %}
+                {% endif %}
                 </tbody>
               </table>
             </div>
@@ -375,16 +375,16 @@
                         <td>{{ name }}</td>
                         <td>{{ value }}</td>
                     </tr>
-                {% end %}
+                {% endfor %}
                 </tbody>
               </table>
             </div>
           </div> <!-- end other tab -->
-          {% end %}
+          {% endif %}
 
          </div>
         </div>
       </div>
   </div>
   </div>
-{% end %}
+{% endblock %}


### PR DESCRIPTION
# What
The error and 404 templates are not consistent with newer versions of Django which makes 404 pages crash when running flower through Django.

When an 404 is raised in Django it finds the templates in flower and fails on the templates.
This is the case I'm trying to solve.

# Changes
- Changed from {% end %} to {% endif %} if there was a conditional statement.
- Changed from {% end %} to {% endblock %} if there was a block.
- Changed from {% end %} to {% endfor %} if there was a for loop.