### PR TITLE
Pass sentinel_kwargs to RedisSentinel() broker

### DIFF
--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -168,7 +168,7 @@ class RedisSentinel(RedisBase):
         self.port = self.port or 26379
         self.vhost = self._prepare_virtual_host(self.vhost)
         self.master_name = self._prepare_master_name(broker_options)
-        self.redis = self._get_redis_client()
+        self.redis = self._get_redis_client(broker_options)
 
     def _prepare_virtual_host(self, vhost):
         if not isinstance(vhost, numbers.Integral):
@@ -194,8 +194,11 @@ class RedisSentinel(RedisBase):
             )
         return master_name
 
-    def _get_redis_client(self):
-        connection_kwargs = {'password': self.password}
+    def _get_redis_client(self, broker_options):
+        connection_kwargs = {
+            'password': self.password,
+            'sentinel_kwargs': broker_options.get('sentinel_kwargs')
+        }
         # TODO: get all sentinel hosts from Celery App config and use them to initialize Sentinel
         sentinel = redis.sentinel.Sentinel(
             [(self.host, self.port)], **connection_kwargs)


### PR DESCRIPTION
Small change to address: https://github.com/mher/flower/issues/1194

The current broker is unable to connect if _both_ Redis and Sentinel are password-protected. The fix is to pass the sentinel password via the `sentinel_kwargs` (https://github.com/redis/redis-py/issues/1388#issuecomment-681960193). Passing the full `broker_options` may be preferable, but I haven't had a chance to test this yet. For reference, this is the `Sentinel` class: https://github.com/redis/redis-py/blob/master/redis/sentinel.py#L144

Difficult to add a meaningful test here, since `redis` is mocked in the tests. I'd generally avoid such mocks, but not an issue for this PR. 