### PR TITLE
Set proper default for RabbitMQ Management API URL

### DIFF
--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -50,7 +50,7 @@ class RabbitMQ(BrokerBase):
         self.password = self.password or 'guest'
 
         if not http_api:
-            http_api = "http://{username}:{password}@{host}:{port}/api/{vhost}".format(
+            http_api = "http://{username}:{password}@{host}:15672/api/{vhost}".format(
                 username=self.username, password=self.password,
                 host=self.host, port=self.port, vhost=self.vhost
             )


### PR DESCRIPTION
Closes #1232

The code was changed in the course of the 0.9 release to use the same
port as the broker for the broker_api, which doesn't work in any
scenario.

Let's revert it back to the default port of 15672.