### PR TITLE
Implement GitLab Authentication using custom GitLab domain via environment variable

### DIFF
--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -168,8 +168,10 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
 
 class GitLabLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
 
-    _OAUTH_AUTHORIZE_URL = 'https://gitlab.com/oauth/authorize'
-    _OAUTH_ACCESS_TOKEN_URL = 'https://gitlab.com/oauth/token'
+    _OAUTH_GITLAB_DOMAIN = os.getenv(
+        "FLOWER_GITLAB_AUTH_DOMAIN", "gitlab.com")
+    _OAUTH_AUTHORIZE_URL = f'https://{_OAUTH_GITLAB_DOMAIN}/oauth/authorize'
+    _OAUTH_ACCESS_TOKEN_URL = f'https://{_OAUTH_GITLAB_DOMAIN}/oauth/token'
     _OAUTH_NO_CALLBACKS = False
 
     @tornado.gen.coroutine
@@ -221,7 +223,7 @@ class GitLabLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
         # Check user email address against regexp
         try:
             response = yield self.get_auth_http_client().fetch(
-                'https://gitlab.com/api/v4/user',
+                f'https://{self._OAUTH_GITLAB_DOMAIN}/api/v4/user',
                 headers={'Authorization': 'Bearer ' + access_token,
                          'User-agent': 'Tornado auth'}
             )
@@ -236,7 +238,7 @@ class GitLabLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
         if allowed_groups:
             min_access_level = os.environ.get('FLOWER_GITLAB_MIN_ACCESS_LEVEL', '20')
             response = yield self.get_auth_http_client().fetch(
-                'https://gitlab.com/api/v4/groups?min_access_level=%s' % (min_access_level,),
+                f'https://{self._OAUTH_GITLAB_DOMAIN}/api/v4/groups?min_access_level={min_access_level}',
                 headers={
                     'Authorization': 'Bearer ' + access_token,
                     'User-agent': 'Tornado auth'


### PR DESCRIPTION
This work aims to provide flexibility in using custom GitLab setups for authentication when using GitLab Auth. You can provide a custom GitLab domain via an environment variable, for example:

```
export FLOWER_GITLAB_AUTH_DOMAIN="gitlab.mycompany.com"
```

If no custom domain is provided, the code defaults to the global `gitlab.com` domain. Closes #1237