### PR TITLE
Fixes #1242 - Ask for safe args strings when calling inspect.active

### DIFF
--- a/flower/inspector.py
+++ b/flower/inspector.py
@@ -35,7 +35,11 @@ class Inspector(object):
 
         logger.debug('Sending %s inspect command', method)
         start = time.time()
-        result = getattr(inspect, method)()
+        result = (
+            getattr(inspect, method)()
+            if method != 'active'
+            else getattr(inspect, method)(safe=True)
+        )
         logger.debug("Inspect command %s took %.2fs to complete", method, time.time() - start)
         
         if result is None or 'error' in result:

--- a/tests/unit/api/test_workers.py
+++ b/tests/unit/api/test_workers.py
@@ -17,29 +17,11 @@ empty_inspect_response = {
     'celery@worker1': []
 }
 
-inspect_response_with_non_serializable_args = {
-    'celery@worker1': {
-        'active': {
-            'id': '1234',
-            'args': [set([1, 2])]
-        }
-    }
-}
-
 
 @mock.patch.object(Inspector, 'methods',
                    new_callable=mock.PropertyMock,
                    return_value=['inspect_method'])
 class ListWorkersTest(AsyncHTTPTestCase):
-
-    def test_non_serialisable_args_in_response(self, m_inspect):
-        celery = self._app.capp
-        celery.control.inspect = mock.Mock()
-        celery.control.inspect.return_value.inspect_method = mock.Mock(
-            return_value=inspect_response_with_non_serializable_args
-        )
-        # this will fail with a response code of 500
-        self.get('/api/workers?refresh=1')
 
     def test_refresh_cache(self, m_inspect):
         celery = self._app.capp

--- a/tests/unit/api/test_workers.py
+++ b/tests/unit/api/test_workers.py
@@ -17,11 +17,29 @@ empty_inspect_response = {
     'celery@worker1': []
 }
 
+inspect_response_with_non_serializable_args = {
+    'celery@worker1' : {
+        'active': {
+            'id': '1234',
+            'args': [set([1,2])]
+        }
+    }
+}
+
 
 @mock.patch.object(Inspector, 'methods',
                    new_callable=mock.PropertyMock,
                    return_value=['inspect_method'])
 class ListWorkersTest(AsyncHTTPTestCase):
+
+    def test_non_serialisable_args_in_response(self, m_inspect):
+        celery = self._app.capp
+        celery.control.inspect = mock.Mock()
+        celery.control.inspect.return_value.inspect_method = mock.Mock(
+            return_value=inspect_response_with_non_serializable_args
+        )
+        # this will fail with a response code of 500
+        self.get('/api/workers?refresh=1')
 
     def test_refresh_cache(self, m_inspect):
         celery = self._app.capp

--- a/tests/unit/api/test_workers.py
+++ b/tests/unit/api/test_workers.py
@@ -1,7 +1,6 @@
 import json
 from unittest import mock
 
-from flower.api.control import ControlHandler
 from flower.inspector import Inspector
 
 from tests.unit import AsyncHTTPTestCase

--- a/tests/unit/api/test_workers.py
+++ b/tests/unit/api/test_workers.py
@@ -18,10 +18,10 @@ empty_inspect_response = {
 }
 
 inspect_response_with_non_serializable_args = {
-    'celery@worker1' : {
+    'celery@worker1': {
         'active': {
             'id': '1234',
-            'args': [set([1,2])]
+            'args': [set([1, 2])]
         }
     }
 }


### PR DESCRIPTION
This PR fixes #1242 

Celery's `inspect.active` accepts `safe` arg which would return safe strings for the objects that are not JSON serializable. This fixes the 500 error that comes in the API calls and I guess views also use the same code, so they would be fixed too.

https://github.com/celery/celery/blob/master/celery/worker/control.py#L367

- I have added a test (32554a1518f4a9cbdb2cc5e3758cec45b67b92fd) to display the issue but later I removed it (5ca140452a76e1ec61cbfe7fff94f55c27c40804) as now celery will not return unsafe strings, so the test did not made sense.
