### PR TITLE
Add support for loading FLOWER_OAUTH2_SECRET as a secret

### DIFF
--- a/flower/command.py
+++ b/flower/command.py
@@ -124,9 +124,15 @@ def extract_settings():
             settings[name] = prepend_url(settings[name], options.url_prefix)
 
     if options.auth:
+        oauth2_secret_file = os.environ.get("FLOWER_OAUTH2_SECRET_FILE", "")
+        oauth2_secret = (
+            options.oauth2_secret or os.environ.get("FLOWER_OAUTH2_SECRET")
+            if not oauth2_secret_file
+            else open(oauth2_secret_file, "r").readline()
+        )
         settings['oauth'] = {
             'key': options.oauth2_key or os.environ.get('FLOWER_OAUTH2_KEY'),
-            'secret': options.oauth2_secret or os.environ.get('FLOWER_OAUTH2_SECRET'),
+            'secret': oauth2_secret,
             'redirect_uri': options.oauth2_redirect_uri or os.environ.get('FLOWER_OAUTH2_REDIRECT_URI'),
         }
 


### PR DESCRIPTION
This will allow one to do the following:

docker-compose.yml
```
version: "3.9"

services:
  celery-worker:
    ...
  
  celery-flower:
    image: mher/flower:1.2
    command: celery --broker=$REDIS_URL flower --port=5555 --auth=".*@my.domain"
    ports:
      - 5555:5555
    environment:
      FLOWER_OAUTH2_SECRET_FILE: /run/secrets/flower_oauth2_secret
    depends_on:
      - celery-worker
    secrets:
      - flower_oauth2_secret

secrets:
  flower_oauth2_secret:
    file: secrets/flower_oauth2_secret
```