### PR TITLE
[sc-88162] only send the aggregate metric, instead of per worker

### DIFF
--- a/flower/events.py
+++ b/flower/events.py
@@ -36,7 +36,7 @@ def get_prometheus_metrics():
 class PrometheusMetrics(object):
 
     def __init__(self):
-        self.events = PrometheusCounter('flower_events_total', "Number of events", ['worker', 'type', 'task'])
+        self.events = PrometheusCounter('flower_events_total', "Number of events", ['type', 'task'])
 
         self.runtime = Histogram(
             'flower_task_runtime_seconds',
@@ -85,7 +85,8 @@ class EventsState(State):
             task_name = event.get('name', '')
             if not task_name and task_id in self.tasks:
                 task_name = task.name or ''
-            self.metrics.events.labels(worker_name, event_type, task_name).inc()
+
+            self.metrics.events.labels(event_type, task_name).inc()
 
             runtime = event.get('runtime', 0)
             if runtime:


### PR DESCRIPTION
We really only care about the aggregate of this metric, not by worker. Until removing offline workers from metrics is implemented, this list grows indefinitely as workers are churned/deployed.