### PR TITLE
Added search arg in List tasks API

### DIFF
--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -524,6 +524,7 @@ List tasks
         received_start = self.get_argument('received_start', None)
         received_end = self.get_argument('received_end', None)
         sort_by = self.get_argument('sort_by', None)
+        search = self.get_argument('search', None)
 
         limit = limit and int(limit)
         offset = max(offset, 0)
@@ -536,7 +537,9 @@ List tasks
                 app.events, limit=limit, offset=offset, sort_by=sort_by, type=type,
                 worker=worker, state=state,
                 received_start=received_start,
-                received_end=received_end):
+                received_end=received_end,
+                search=search
+        ):
             task = tasks.as_dict(task)
             worker = task.pop('worker', None)
             if worker is not None:

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -191,3 +191,31 @@ class TaskTests(AsyncHTTPTestCase):
         self.assertEqual("task2", firstFetchedTaskName)
         self.assertEqual("task3", lastFetchedTaskName)
 
+            # Test limit 4 with search
+            params = dict(limit=4, offset=0, sort_by='name', search='task')
+
+            r = self.get('/api/tasks?' + '&'.join(
+                            map(lambda x: '%s=%s' % x, params.items())))
+
+            table = json.loads(r.body.decode("utf-8"), object_pairs_hook=OrderedDict)
+
+            self.assertEqual(200, r.code)
+            self.assertEqual(4, len(table))
+            firstFetchedTaskName = table[list(table)[0]]['name']
+            lastFetchedTaskName =  table[list(table)[-1]]['name']
+            self.assertEqual("task1", firstFetchedTaskName)
+            self.assertEqual("task4", lastFetchedTaskName)
+
+            # Test limit 4 with search
+            params = dict(limit=4, offset=0, sort_by='name', search='task1')
+
+            r = self.get('/api/tasks?' + '&'.join(
+                            map(lambda x: '%s=%s' % x, params.items())))
+
+            table = json.loads(r.body.decode("utf-8"), object_pairs_hook=OrderedDict)
+
+            self.assertEqual(200, r.code)
+            self.assertEqual(1, len(table))
+            firstFetchedTaskName = table[list(table)[0]]['name']
+            self.assertEqual("task1", firstFetchedTaskName)
+

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -191,31 +191,31 @@ class TaskTests(AsyncHTTPTestCase):
         self.assertEqual("task2", firstFetchedTaskName)
         self.assertEqual("task3", lastFetchedTaskName)
 
-            # Test limit 4 with search
-            params = dict(limit=4, offset=0, sort_by='name', search='task')
+        # Test limit 4 with search
+        params = dict(limit=4, offset=0, sort_by='name', search='task')
 
-            r = self.get('/api/tasks?' + '&'.join(
-                            map(lambda x: '%s=%s' % x, params.items())))
+        r = self.get('/api/tasks?' + '&'.join(
+                        map(lambda x: '%s=%s' % x, params.items())))
 
-            table = json.loads(r.body.decode("utf-8"), object_pairs_hook=OrderedDict)
+        table = json.loads(r.body.decode("utf-8"), object_pairs_hook=OrderedDict)
 
-            self.assertEqual(200, r.code)
-            self.assertEqual(4, len(table))
-            firstFetchedTaskName = table[list(table)[0]]['name']
-            lastFetchedTaskName =  table[list(table)[-1]]['name']
-            self.assertEqual("task1", firstFetchedTaskName)
-            self.assertEqual("task4", lastFetchedTaskName)
+        self.assertEqual(200, r.code)
+        self.assertEqual(4, len(table))
+        firstFetchedTaskName = table[list(table)[0]]['name']
+        lastFetchedTaskName =  table[list(table)[-1]]['name']
+        self.assertEqual("task1", firstFetchedTaskName)
+        self.assertEqual("task4", lastFetchedTaskName)
 
-            # Test limit 4 with search
-            params = dict(limit=4, offset=0, sort_by='name', search='task1')
+        # Test limit 4 with search
+        params = dict(limit=4, offset=0, sort_by='name', search='task1')
 
-            r = self.get('/api/tasks?' + '&'.join(
-                            map(lambda x: '%s=%s' % x, params.items())))
+        r = self.get('/api/tasks?' + '&'.join(
+                        map(lambda x: '%s=%s' % x, params.items())))
 
-            table = json.loads(r.body.decode("utf-8"), object_pairs_hook=OrderedDict)
+        table = json.loads(r.body.decode("utf-8"), object_pairs_hook=OrderedDict)
 
-            self.assertEqual(200, r.code)
-            self.assertEqual(1, len(table))
-            firstFetchedTaskName = table[list(table)[0]]['name']
-            self.assertEqual("task1", firstFetchedTaskName)
+        self.assertEqual(200, r.code)
+        self.assertEqual(1, len(table))
+        firstFetchedTaskName = table[list(table)[0]]['name']
+        self.assertEqual("task1", firstFetchedTaskName)
 


### PR DESCRIPTION
Adds all search features like:
- `search="state:FAILED"` -- returns tasks in FAILED state
- `search="args:foo"` -- returns tasks with any arg=foo
- `search=foobar` -- matches with anything foo
and more...