### PR TITLE
Fix environment variable names at git custom domain authentication

### DIFF
--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -92,7 +92,7 @@ class LoginHandler(BaseHandler):
 class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
 
     _OAUTH_DOMAIN = os.getenv(
-        "FLOWER_GITLAB_OAUTH_DOMAIN", "github.com")
+        "FLOWER_GITHUB_OAUTH_DOMAIN", "github.com")
     _OAUTH_AUTHORIZE_URL = f'https://{_OAUTH_DOMAIN}/login/oauth/authorize'
     _OAUTH_ACCESS_TOKEN_URL = f'https://{_OAUTH_DOMAIN}/login/oauth/access_token'
     _OAUTH_NO_CALLBACKS = False
@@ -167,7 +167,7 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
 class GitLabLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
 
     _OAUTH_GITLAB_DOMAIN = os.getenv(
-        "FLOWER_GITLAB_AUTH_DOMAIN", "gitlab.com")
+        "FLOWER_GITLAB_OAUTH_DOMAIN", "gitlab.com")
     _OAUTH_AUTHORIZE_URL = f'https://{_OAUTH_GITLAB_DOMAIN}/oauth/authorize'
     _OAUTH_ACCESS_TOKEN_URL = f'https://{_OAUTH_GITLAB_DOMAIN}/oauth/token'
     _OAUTH_NO_CALLBACKS = False


### PR DESCRIPTION
The environment variables that were introduced at #1263 for custom domain auth in Gitlab and Github were not the correct ones, as specified in the documentation:
https://github.com/mher/flower/blob/55558ba639433bada90a6d505f81ab7eb167aff9/docs/auth.rst?plain=1#L103-L104

https://github.com/mher/flower/blob/55558ba639433bada90a6d505f81ab7eb167aff9/docs/auth.rst?plain=1#L135-L136

