### PR TITLE
add queues column to workers tab

### DIFF
--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -468,6 +468,17 @@ var flower = (function () {
                 }
             }, {
                 targets: 1,
+                data: 'active_queues',
+                className: "text-center",
+                render: function (data, type, full, meta) {
+                    if (Array.isArray(data)) {
+                        return data.map(x => x['name']).join(', ');
+                    } else {
+                        return '&nbsp';
+                    }
+                }
+            }, {
+                targets: 2,
                 data: 'status',
                 className: "text-center",
                 width: "10%",
@@ -479,37 +490,37 @@ var flower = (function () {
                     }
                 }
             }, {
-                targets: 2,
+                targets: 3,
                 data: 'active',
                 className: "text-center",
                 width: "10%",
                 defaultContent: 0
             }, {
-                targets: 3,
+                targets: 4,
                 data: 'task-received',
                 className: "text-center",
                 width: "10%",
                 defaultContent: 0
             }, {
-                targets: 4,
+                targets: 5,
                 data: 'task-failed',
                 className: "text-center",
                 width: "10%",
                 defaultContent: 0
             }, {
-                targets: 5,
+                targets: 6,
                 data: 'task-succeeded',
                 className: "text-center",
                 width: "10%",
                 defaultContent: 0
             }, {
-                targets: 6,
+                targets: 7,
                 data: 'task-retried',
                 className: "text-center",
                 width: "10%",
                 defaultContent: 0
             }, {
-                targets: 7,
+                targets: 8,
                 data: 'loadavg',
                 width: "10%",
                 className: "text-center text-nowrap",

--- a/flower/templates/workers.html
+++ b/flower/templates/workers.html
@@ -11,6 +11,7 @@
       <thead>
         <tr>
           <th>Worker</th>
+          <th>Queues</th>
           <th class="text-center">Status</th>
           <th class="text-center">Active</th>
           <th class="text-center">Processed</th>
@@ -24,6 +25,7 @@
         {% for name, info in workers.items() %}
         <tr id="{{ url_escape(name) }}">
           <td>{{ name }}</td>
+          <td>{{ " ,".join(map(lambda queue: queue['name'], info.get('active_queues', []))) }}</td>
           <td>{{ info.get('status', None) }}</td>
           <td>{{ info.get('active', 0) or 0 }}</td>
           <td>{{ info.get('task-received', 0) }}</td>

--- a/flower/views/workers.py
+++ b/flower/views/workers.py
@@ -46,9 +46,10 @@ class WorkersView(BaseHandler):
             if name not in events.workers:
                 continue
             worker = events.workers[name]
+            full_worker_info = self.application.workers.get(name)
             info = dict(values)
             info.update(self._as_dict(worker))
-            info.update(status=worker.alive)
+            info.update({'status': worker.alive, 'active_queues': full_worker_info.get('active_queues', [])})
             workers[name] = info
 
         if options.purge_offline_workers is not None:


### PR DESCRIPTION
I propose to add queue(s) names as a column on Brokers tab.

This PR helps with the following use case. Frequently I want to see at a glance status of workers consuming specific queue: 

- are there workers listening to a specific queue
- how many of them are online
- how many of them are busy now and how many have capacities
