### PR TITLE
Correct hyperlinks with custom `url_prefix` applied

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,5 +36,5 @@ jobs:
     - name: Run unit tests
       run: |
         python -m flower --version
-        python -m tests.unit.__main__
+        python -m tests.unit
 

--- a/docs/reverse-proxy.rst
+++ b/docs/reverse-proxy.rst
@@ -5,22 +5,34 @@ Running behind reverse proxy
 
 To run `Flower` behind a reverse proxy, remember to set the correct `Host` 
 header to the request to make sure Flower can generate correct URLs.
-The following is a minimal `nginx` configuration:
+
+The following block represents the minimal `nginx` configuration:
 
 .. code-block:: nginx
 
     server {
         listen 80;
         server_name flower.example.com;
-        charset utf-8;
 
         location / {
             proxy_pass http://localhost:5555;
-            proxy_set_header Host $host;
-            proxy_redirect off;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+        }
+    }
+
+If you run Flower behind custom location, make sure :ref:`url_prefix` option
+value equals to the location path.
+
+For instance, for `url_prefix` = **flower** (or **/flower**) you need the following
+`nginx` configuration:
+
+.. code-block:: nginx
+
+    server {
+        listen 80;
+        server_name flower.example.com;
+
+        location /flower/ {
+            proxy_pass http://localhost:5555;
         }
     }
 

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -1,11 +1,8 @@
 server {
-    location /flower/static {
-        alias  /the/path/to/flower/static;
-    }
-    location /flower {
-        rewrite ^/flower/(.*)$ /$1 break;
+    listen 80;
+
+    # with url_prefix=`flower`
+    location /flower/ {
         proxy_pass http://localhost:5555;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
     }
 }

--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -450,11 +450,8 @@ var flower = (function () {
                     var total = api.column(column).data().reduce(sum, 0);
                     var footer = total;
                     if (total !== 0) {
-                        footer = '<a href="/tasks';
-                        if (state !== "") {
-                            footer += '?state=' + state;
-                        }
-                        footer += '">' + total + '</a>';
+                        let queryParams = (state !== '' ? `?state=${state}` : '');
+                        footer = '<a href="' + url_prefix() + '/tasks' + queryParams + '">' + total + '</a>';
                     }
                     $(api.column(column).footer()).html(footer);
                 }

--- a/flower/templates/navbar.html
+++ b/flower/templates/navbar.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-green mx-2">
   <a class="navbar-brand" href="{{ reverse_url('main') }}">
-    <img src="/favicon.ico" width="30" height="30" class="d-inline-block align-top" alt="">
+    <img src="{{ static_url('favicon.ico') }}" width="30" height="30" class="d-inline-block align-top" alt="">
     Flower
   </a>
   <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"

--- a/tests/run-unit-tests.sh
+++ b/tests/run-unit-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-python -m tests.unit.__main__
+python -m tests.unit

--- a/tests/unit/views/test_url_handlers.py
+++ b/tests/unit/views/test_url_handlers.py
@@ -24,25 +24,26 @@ class UrlsTests(AsyncHTTPTestCase):
 
 class URLPrefixTests(AsyncHTTPTestCase):
     def setUp(self):
-        with self.mock_option('url_prefix', 'test_root'):
+        self.url_prefix = '/test_root'
+        with self.mock_option('url_prefix', self.url_prefix):
             super().setUp()
 
     def test_tuple_handler_rewrite(self):
-        r = self.get('/test_root/workers')
+        r = self.get(self.url_prefix + '/workers')
         self.assertEqual(200, r.code)
 
     def test_root_url(self):
-        r = self.get('/test_root/')
+        r = self.get(self.url_prefix + '/')
         self.assertEqual(200, r.code)
 
     def test_tasks_api_url(self):
-        with patch.dict(os.environ, {"FLOWER_UNAUTHENTICATED_API": "true"}):
-            r = self.get('/test_root/api/tasks')
+        with patch.dict(os.environ, {'FLOWER_UNAUTHENTICATED_API': 'true'}):
+            r = self.get(self.url_prefix + '/api/tasks')
             self.assertEqual(200, r.code)
 
     def test_base_url_no_longer_working(self):
-        r = self.get('/workers')
-        self.assertNotEqual(200, r.code)
+        r = self.get('/')
+        self.assertEqual(404, r.code)
 
 
 class RewriteHandlerTests(AsyncHTTPTestCase):


### PR DESCRIPTION
Templates and scripts had invalid links during running behind proxy with non-empty `url_prefix`.
It resulted in missing Celery icon in the navbar and invalid task links located in the workers table footer.
Now `<a>` tag of favicon takes into account prepended `url_prefix` and JS-generated links have a missing `url_prefix()`

Before:
![image](https://github.com/mher/flower/assets/62136362/609d9089-be22-4dab-9976-5cfedf2d94f0)

After:
![image](https://github.com/mher/flower/assets/62136362/31d77b0e-8dd9-4f09-8af0-4f619a393a22)
