### PR TITLE
add `text-overflow` property on the `.overflow-auto` class

### DIFF
--- a/flower/static/css/flower.css
+++ b/flower/static/css/flower.css
@@ -33,6 +33,7 @@ div.dataTables_wrapper .dataTables_filter input {
 
 .overflow-auto {
   max-width: 400px;
+  text-overflow: ellipsis;
 }
 
 .overflow-auto::-webkit-scrollbar {


### PR DESCRIPTION
When stumbled upon the issue described in #1295, the proposed change worked for me.

Before:

![image](https://github.com/mher/flower/assets/68805512/2c7cc23d-8e46-4ff6-8724-f94347cd3539)

After:

![image](https://github.com/mher/flower/assets/68805512/2c99bde8-c930-495f-becf-8fbaed06d07f)
