### PR TITLE
Censor all information from worker options tab

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -540,3 +540,10 @@ Default: None
 Sets the URI to which an OAuth 2.0 server redirects the user after successful authentication and authorization.
 
 `oauth2_redirect_uri` option should be used with :ref:`auth`, :ref:`auth_provider`, :ref:`oauth2_key` and :ref:`oauth2_secret` options.
+
+censor_config
+~~~~~~~~~~~~~
+
+Default: False
+
+Censors all fields in all worker's config tabs

--- a/flower/__init__.py
+++ b/flower/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (2, 0, 0)
+VERSION = (2, 0, 1)
 __version__ = '.'.join(map(str, VERSION)) + '-dev'

--- a/flower/options.py
+++ b/flower/options.py
@@ -68,6 +68,8 @@ define("auth_provider", default=None, type=str, help="auth handler class")
 define("url_prefix", type=str, help="base url prefix")
 define("task_runtime_metric_buckets", type=float, default=Histogram.DEFAULT_BUCKETS,
        multiple=True, help="histogram latency bucket value")
+define("censor_config", type=bool, default=False, 
+       help="censor config from web interface")
 
 
 default_options = options

--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -333,14 +333,23 @@
                 <caption>Configuration options</caption>
                 <tbody>
                   {% for name,value in sorted(worker.get('conf', {}).items()) %}
-                  {% if value is not None %}
-                  <tr>
-                    <td><a
-                        href="https://docs.celeryq.dev/en/latest/userguide/configuration.html#{{ name.lower().replace('_', '-') }}"
-                        target="_blank">{{ name }}</a></td>
-                    <td>{{ value }}</td>
-                  </tr>
-                  {% end %}
+                    {% if value is not None %}
+                      {% if name == "config" %}
+                      <tr>
+                        <td><a href="http://docs.celeryproject.org/en/latest/userguide/configuration.html#{{ name.lower().replace('_', '-') }}" target="_blank">{{ name }}</a></td>
+                        {% if censor_config == True %}
+                        <td><em>Censored</em></td>
+                        {% else %}
+                        <td>{{ value }}</td>
+                        {% end %}
+                      </tr>
+                      {% else %}
+                      <tr>
+                        <td><a href="http://docs.celeryproject.org/en/latest/userguide/configuration.html#{{ name.lower().replace('_', '-') }}" target="_blank">{{ name }}</a></td>
+                        <td>{{ value }}</td>
+                      </tr>
+                      {% end %}
+                    {% end %}
                   {% end %}
                 </tbody>
               </table>

--- a/flower/templates/worker.html
+++ b/flower/templates/worker.html
@@ -334,7 +334,6 @@
                 <tbody>
                   {% for name,value in sorted(worker.get('conf', {}).items()) %}
                     {% if value is not None %}
-                      {% if name == "config" %}
                       <tr>
                         <td><a href="http://docs.celeryproject.org/en/latest/userguide/configuration.html#{{ name.lower().replace('_', '-') }}" target="_blank">{{ name }}</a></td>
                         {% if censor_config == True %}
@@ -396,4 +395,3 @@
       </div>
     </div>
   </div>
-  {% end %}

--- a/flower/views/workers.py
+++ b/flower/views/workers.py
@@ -24,7 +24,7 @@ class WorkerView(BaseHandler):
         if 'stats' not in worker:
             raise web.HTTPError(404, f"Unable to get stats for '{name}' worker")
 
-        self.render("worker.html", worker=dict(worker, name=name))
+        self.render("worker.html", worker=dict(worker, name=name), censor_config=options.censor_config)
 
 
 class WorkersView(BaseHandler):


### PR DESCRIPTION
Flower will be default expose all objects in a celery worker in its config tab. See for example this worker:

```
import os
import time
from datetime import datetime

from celery import Celery

app = Celery("tasks",
             broker=os.environ.get('CELERY_BROKER_URL', 'pyamqp://0.0.0.0:5672'),
             )
app.conf.accept_content = ['pickle', 'json', 'msgpack', 'yaml']
app.conf.worker_send_task_events = True
app.conf.config = {"aaa":"bbbb"}

@app.task
def add(x, y):
    return x + y

if __name__ == "__main__":
    app.start()
```

![image](https://github.com/mher/flower/assets/5174034/4e705ea6-37ec-4c10-a234-44ae37245535)

By default, there is some censoring of information so that the password for the amqp broker is replaced with stars, though this is no perfect. In practice, you can "smuggle" sensitive information out by using non standard key names (also, I don't know what is doing this fuzzy censoring, so if anyone could point that out, it would be appreciated).

This pull request adds complete censoring of all values in the config tab, but will still display the keys (objects).

Running flower with the `--censor-config` flag will produce the following config tab:
![image](https://github.com/mher/flower/assets/5174034/45e5caec-a93e-4bcb-a194-d499fb9d67b7)
