### PR TITLE
Github Enterprise has a different API endpoint compared to Free/Pro/teams version

### DIFF
--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -86,6 +86,8 @@ Here's an example configuration file with the Github OAuth options:
 Replace `<your_client_id>` and `<your_client_secret>` with the actual  Client ID and secret obtained from
 the Github Settings.
 
+If using Github Enterprise, you can set the `FLOWER_GITHUB_OAUTH_DOMAIN` environment variable to the base URL of your Github Enterprise instance.
+
 See `GitHub OAuth API`_ docs for more info.
 
 .. _Github Settings: https://github.com/settings/applications/new

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -90,6 +90,10 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
 
     _OAUTH_DOMAIN = os.getenv(
         "FLOWER_GITHUB_OAUTH_DOMAIN", "github.com")
+    if _OAUTH_DOMAIN == "github.com":
+        _OAUTH_API_URL = f'https://api.{_OAUTH_DOMAIN}/user/emails'
+    else:
+        _OAUTH_API_URL = f'https://{_OAUTH_DOMAIN}/api/v3/user/emails'
     _OAUTH_AUTHORIZE_URL = f'https://{_OAUTH_DOMAIN}/login/oauth/authorize'
     _OAUTH_ACCESS_TOKEN_URL = f'https://{_OAUTH_DOMAIN}/login/oauth/access_token'
     _OAUTH_NO_CALLBACKS = False
@@ -138,7 +142,7 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
         access_token = user['access_token']
 
         response = await self.get_auth_http_client().fetch(
-            f'https://api.{self._OAUTH_DOMAIN}/user/emails',
+            self._OAUTH_API_URL,
             headers={'Authorization': 'token ' + access_token,
                      'User-agent': 'Tornado auth'})
 


### PR DESCRIPTION
Added an if conditional to switch the `_OAUTH_API_URL` if using a custom domain other than `github.com`.
Fixes: #1308 