### PR TITLE
Feature - Drop old tasks with max_count or timedelta

### DIFF
--- a/flower/app.py
+++ b/flower/app.py
@@ -62,7 +62,9 @@ class Flower(tornado.web.Application):
             enable_events=self.options.enable_events,
             io_loop=self.io_loop,
             max_workers_in_memory=self.options.max_workers,
-            max_tasks_in_memory=self.options.max_tasks)
+            max_tasks_in_memory=self.options.max_tasks,
+            limit_tasks_by_type=self.options.limit_tasks_by_type
+        )
         self.started = False
 
     def start(self):

--- a/flower/options.py
+++ b/flower/options.py
@@ -31,6 +31,8 @@ define("max_workers", type=int, default=5000,
        help="maximum number of workers to keep in memory")
 define("max_tasks", type=int, default=100000,
        help="maximum number of tasks to keep in memory")
+define("limit_tasks_by_type", type=list, default=[],
+       help="limits number of tasks to keep in memory by type (by max number or timedelta)")
 define("db", type=str, default='flower',
        help="flower database file")
 define("persistent", type=bool, default=False,


### PR DESCRIPTION
It would be useful to have the ability to drop tasks in flower: in my case there is a task that runs pretty frequent (for example 2 every mins) and it's important to see last 10 runs and would be better to drop all not important tasks.

This solution is similar to this PR https://github.com/mher/flower/pull/1188 but I think my approach is better.
You need to add one list in  flowerconfig.py and that's all: 

`limit_tasks_by_type=[
    {'type': 'test_task', "max_count": 10, "timedelta": timedelta(minutes=10)},
]`


It will keep 10 newest test_task and drop everything else and drop any test_task older that 10 minutes 