### PR TITLE
add ssl support for redis with sentinel

### DIFF
--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -159,7 +159,7 @@ class RedisSentinel(RedisBase):
     def __init__(self, broker_url, *args, **kwargs):
         super().__init__(broker_url, *args, **kwargs)
         broker_options = kwargs.get('broker_options', {})
-        broker_use_ssl = kwargs.get('broker_use_ssl', {})
+        broker_use_ssl = kwargs.get('broker_use_ssl', None)
         self.host = self.host or 'localhost'
         self.port = self.port or 26379
         self.vhost = self._prepare_virtual_host(self.vhost)

--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -159,11 +159,12 @@ class RedisSentinel(RedisBase):
     def __init__(self, broker_url, *args, **kwargs):
         super().__init__(broker_url, *args, **kwargs)
         broker_options = kwargs.get('broker_options', {})
+        broker_use_ssl = kwargs.get('broker_use_ssl', {})
         self.host = self.host or 'localhost'
         self.port = self.port or 26379
         self.vhost = self._prepare_virtual_host(self.vhost)
         self.master_name = self._prepare_master_name(broker_options)
-        self.redis = self._get_redis_client(broker_options)
+        self.redis = self._get_redis_client(broker_options, broker_use_ssl)
 
     def _prepare_virtual_host(self, vhost):
         if not isinstance(vhost, numbers.Integral):
@@ -184,11 +185,14 @@ class RedisSentinel(RedisBase):
             raise ValueError('master_name is required for Sentinel broker') from exc
         return master_name
 
-    def _get_redis_client(self, broker_options):
+    def _get_redis_client(self, broker_options, broker_use_ssl):
         connection_kwargs = {
             'password': self.password,
             'sentinel_kwargs': broker_options.get('sentinel_kwargs')
         }
+        if isinstance(broker_use_ssl, dict):
+            connection_kwargs['ssl'] = True
+            connection_kwargs.update(broker_use_ssl)
         # get all sentinel hosts from Celery App config and use them to initialize Sentinel
         sentinel = redis.sentinel.Sentinel(
             [(self.host, self.port)], **connection_kwargs)


### PR DESCRIPTION
flower can already connect to sentinel using tls by setting `sentinel_kwargs` in `broker_options` accordingly, e.g.:
```
'sentinel_kwargs': { 'ssl': True, 'ssl_cert_reqs': ssl.CERT_NONE }
```

to enable tls to sentinel without sending any client certificate or validating the server certificate.
this will be passed to the Sentinel() constructor and works fine for the connection from flower to sentinel.

however, this is only one of the two connections made from flower in a sentinel+redis setup...
the next connection which is made to the returned redis master was always without tls.

to make the connection to redis also use tls, one has to pass the according ssl related [connection_kwargs](https://github.com/redis/redis-py/blob/cc4bc1a544d1030aec1696baef2861064fa8dd1c/redis/sentinel.py#L215) to Sentinel() constructor.

I adapted the code from the existing encrypted redis-only case by reusing `broker_use_ssl` settings in the sentinel+redis setup to configure whether the connection to redis should be made using tls or not. checking if `broker_use_ssl` is defined, and if so, set `ssl` to `True` and inject the parameters provided in `broker_use_ssl` for the connection from flower to redis. this way flower can be configured to use tls on both, the sentinel AND the redis connection using existing configuration settings and it's working fine for me now...

PS: This also fixes a `500` error for redis+sentinel on `/broker` route with a server error `104 - Connection reset by peer` indicating that connection to redis was made without tls.