### PR TITLE
Add Python 3.12 to test matrix and add classifier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         celery-version: ['5.2', '5.3']
         tornado-version: ['6.0']
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.9"
   - "3.10"
   - "3.11"
+  - "3.12"
   - "pypy3"
 install:
   - pip install tox-travis

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ classes = """
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39,py310,py311,pypy3}-{celery505}-{tornado5,tornado6}
+envlist = {py36,py37,py38,py39,py310,py311,py312,pypy3}-{celery505}-{tornado5,tornado6}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
When a new version of `kombu` is released flower should support Python 3.12 