### PR TITLE
Feature - record / persist only failed tasks

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -541,9 +541,13 @@ Sets the URI to which an OAuth 2.0 server redirects the user after successful au
 
 `oauth2_redirect_uri` option should be used with :ref:`auth`, :ref:`auth_provider`, :ref:`oauth2_key` and :ref:`oauth2_secret` options.
 
+.. _persist_only_failed_tasks:
+
 persist_only_failed_tasks
 ~~~~~~~~~~~~~~~~~~~
 
 Default: False
 
 Config to persist only failed tasks
+
+.. Note:: When persist_only_failed_tasks mode is enabled, Flower only show failed tasks, but still count number of other tasks.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -540,3 +540,10 @@ Default: None
 Sets the URI to which an OAuth 2.0 server redirects the user after successful authentication and authorization.
 
 `oauth2_redirect_uri` option should be used with :ref:`auth`, :ref:`auth_provider`, :ref:`oauth2_key` and :ref:`oauth2_secret` options.
+
+persist_only_failed_tasks
+~~~~~~~~~~~~~~~~~~~
+
+Default: False
+
+Config to persist only failed tasks

--- a/flower/events.py
+++ b/flower/events.py
@@ -98,7 +98,7 @@ class EventsState(State):
 
             if options.persist_only_failed_tasks:
                 if event_type in ['task-succeeded', 'task-revoked']:
-                    del self.tasks[task_id]               
+                    del self.tasks[task_id]
 
         if event_type == 'worker-online':
             self.metrics.worker_online.labels(worker_name).set(1)

--- a/flower/events.py
+++ b/flower/events.py
@@ -99,6 +99,7 @@ class EventsState(State):
             if options.persist_only_failed_tasks:
                 if event_type in ['task-succeeded', 'task-revoked']:
                     del self.tasks[task_id]
+                    self.rebuild_taskheap()
 
         if event_type == 'worker-online':
             self.metrics.worker_online.labels(worker_name).set(1)

--- a/flower/events.py
+++ b/flower/events.py
@@ -96,6 +96,10 @@ class EventsState(State):
             if event_type in ['task-succeeded', 'task-failed'] and not task.eta and task_started and task_received:
                 self.metrics.prefetch_time.labels(worker_name, task_name).set(0)
 
+            if options.persist_only_failed_tasks:
+                if event_type in ['task-succeeded', 'task-revoked']:
+                    del self.tasks[task_id]               
+
         if event_type == 'worker-online':
             self.metrics.worker_online.labels(worker_name).set(1)
 

--- a/flower/options.py
+++ b/flower/options.py
@@ -68,6 +68,6 @@ define("auth_provider", default=None, type=str, help="auth handler class")
 define("url_prefix", type=str, help="base url prefix")
 define("task_runtime_metric_buckets", type=float, default=Histogram.DEFAULT_BUCKETS,
        multiple=True, help="histogram latency bucket value")
-
+define("persist_only_failed_tasks", type=bool, help="Persist only failed tasks", default=False)
 
 default_options = options


### PR DESCRIPTION
from issue: #1250 , i think it's very cool if we have a flag config to make Flower persist only failed tasks.

