### PR TITLE
Adding Auth0 as another option for login

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Features
     - Revoke or terminate tasks
 - Broker monitoring
     - View statistics for all Celery queues
-- HTTP Basic Auth, Google, Github, Gitlab and Okta OAuth
+- HTTP Basic Auth, Google, Github, Gitlab, Okta and Auth0 OAuth
 - Prometheus integration
 - API
 

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -4,7 +4,7 @@ Authentication
 ==============
 
 Flower supports a variety of authentication methods, including Basic Authentication, Google, GitHub,
-GitLab, and Okta OAuth. You can also customize and use your own authentication method.
+GitLab, Okta and Auth0 OAuth. You can also customize and use your own authentication method.
 
 The following endpoints are exempt from authentication:
 
@@ -97,7 +97,7 @@ Okta OAuth
 ----------
 
 Flower also supports Okta OAuth. Before getting started, you need to register Flower in `Okta`_.
-Okta OAuth is activated by setting :ref:`auth_provider` option to `flower.views.auth.OktaLoginHandler`.
+Okta OAuth is activated by setting :ref:`auth_provider` option to `flower.views.auth.OktaLoginHandler`.
 
 Okta OAuth requires `oauth2_key`, `oauth2_secret` and `oauth2_redirect_uri` options which should be obtained from Okta.
 Okta OAuth also uses `FLOWER_OAUTH2_OKTA_BASE_URL` environment variable.
@@ -106,6 +106,22 @@ See Okta `Okta OAuth API`_ docs for more info.
 
 .. _Okta: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/main/
 .. _Okta OAuth API: https://developer.okta.com/docs/reference/api/oidc/
+
+.. _auth0-oauth:
+
+Auth0 OAuth
+----------
+
+Flower also supports Auth0 OAuth. Before getting started, you need to register Flower in `Auth0`_ as a "Regular Web Application".
+Auth0 OAuth is activated by setting :ref:`auth_provider` option to `flower.views.auth.Auth0LoginHandler`.
+
+Auth0 OAuth requires `oauth2_key`, `oauth2_secret` and `oauth2_redirect_uri` options which should be obtained from Auth0.
+Auth0 OAuth also uses `FLOWER_OAUTH2_AUTH0_BASE_URL` environment variable.
+
+See Auth0 `Auth0 OAuth API`_ docs for more info.
+
+.. _Auth0: https://auth0.com/docs/get-started/auth0-overview/create-applications/regular-web-apps
+.. _Auth0 OAuth API: https://auth0.com/docs/api/authentication
 
 .. _gitlab-oauth:
 
@@ -130,6 +146,6 @@ It provides comprehensive information and guidelines on working with GitLab's OA
 
 See also `GitLab OAuth2 API`_ documentation for more info.
 
-.. _GitLab OAuth documentation: https://docs.gitlab.com/ee/integration/oauth_provider.htm
+.. _GitLab OAuth documentation: https://docs.gitlab.com/ee/integration/oauth_provider.html
 .. _GitLab OAuth2 API: https://docs.gitlab.com/ee/api/oauth2.html
 .. _Group and project members API: https://docs.gitlab.com/ee/api/members.html

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -476,6 +476,7 @@ To enable authentication and specify an authentication provider, set the `auth_p
   - GitHub `flower.views.auth.GithubLoginHandler`
   - GitLab `flower.views.auth.GitLabLoginHandler`
   - Okta `flower.views.auth.OktaLoginHandler`
+  - Auth0 `flower.views.auth.Auth0LoginHandler`
 
 See also :ref:`Authentication` for usage examples
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -19,7 +19,7 @@ Features
 - Broker monitoring
     - View statistics for all Celery queues
 
-- HTTP Basic Auth, Google, Github, Gitlab and Okta OAuth
+- HTTP Basic Auth, Google, Github, Gitlab, Okta and Auth0 OAuth
 
 - Prometheus integration
 

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -349,3 +349,21 @@ class OktaLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
         if self.application.options.url_prefix and next_[0] != '/':
             next_ = '/' + next_
         self.redirect(next_)
+
+
+class Auth0LoginHandler(OktaLoginHandler):
+    @property
+    def base_url(self):
+        return os.environ.get("FLOWER_OAUTH2_AUTH0_BASE_URL")
+
+    @property
+    def _OAUTH_AUTHORIZE_URL(self):
+        return f"https://{self.base_url}/oauth/authorize"
+
+    @property
+    def _OAUTH_ACCESS_TOKEN_URL(self):
+        return f"https://{self.base_url}/login/oauth/token"
+
+    @property
+    def _OAUTH_USER_INFO_URL(self):
+        return f"https://{self.base_url}/userinfo"


### PR DESCRIPTION
I've added an option to login using Auth0 via a new `Auth0LoginHandler`. It's ultimately quite similar to Okta (who are coincidentally their parent company), but with slightly different authorization, token and userinfo endpoints. In addition there are a couple of small changes I made (github's documentation link ended in .htm instead of .html, and Okta's section contained a small unprintable character).