### PR TITLE
Use celery app timezone

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -331,6 +331,16 @@ Enables showing time relative to the page refresh time in a more human-readable 
 
 When enabled, timestamps will be shown as relative time such as "2 minutes ago" or "1 hour ago" instead of the exact timestamp.
 
+
+.. _browser_local_time:
+
+browser_local_time
+~~~~~~~~~~~~~~~~~~
+
+Default: False
+
+Show time in the browser's local timezone. If not specified, or set to `False`, the timezone of the Celery app is used.
+
 .. _persistent:
 
 persistent

--- a/docs/man.rst
+++ b/docs/man.rst
@@ -55,6 +55,7 @@ OPTIONS
                                    basic auth
   --broker-api                     inspect broker e.g.
                                    http://guest:guest@localhost:15672/api/
+  --browser-local-time             show time in the browser's local TZ (default *False*)
   --ca-certs                       path to SSL certificate authority (CA) file
   --certfile                       path to SSL certificate file
   --conf                           flower configuration file path (default *flowerconfig.py*)

--- a/flower/options.py
+++ b/flower/options.py
@@ -61,6 +61,8 @@ define("format_task", type=types.FunctionType, default=None,
        help="use custom task formatter")
 define("natural_time", type=bool, default=False,
        help="show time in relative format")
+define("browser_local_time", type=bool, default=False,
+       help="show time in the browser's local TZ")
 define("tasks_columns", type=str,
        default="name,uuid,state,args,kwargs,result,received,started,runtime,worker",
        help="slugs of columns on /tasks/ page, delimited by comma")

--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -525,14 +525,18 @@ var flower = (function () {
     }
 
     function format_time(timestamp) {
-        var time = $('#time').val(),
-            prefix = time.startsWith('natural-time') ? 'natural-time' : 'time',
-            tz = time.substr(prefix.length + 1) || 'UTC';
+        var time = $('#time').val()
+        var prefix = time.startsWith('natural-time') ? 'natural-time' : 'time'
+        var tz = time.substr(prefix.length + 1) || moment.tz.guess(); // Use browser's local TZ if not set
+
+        var m = moment.unix(timestamp).tz(tz);
+        var fullTime = m.format('YYYY-MM-DD HH:mm:ss.SSS'); // full date/time without TZ
 
         if (prefix === 'natural-time') {
-            return moment.unix(timestamp).tz(tz).fromNow();
+            return '<span title="' + fullTime + ' (' + tz + ')">' + m.fromNow() + '</span>';
         }
-        return moment.unix(timestamp).tz(tz).format('YYYY-MM-DD HH:mm:ss.SSS');
+
+        return '<span title="' + m.fromNow() + ' (' + tz + ')">' + fullTime + '</span>';
     }
 
     function usesNaturalTime() {
@@ -929,8 +933,7 @@ var flower = (function () {
                             return format_time(data);
                         }
                         return '<time datetime="' + moment.unix(data).toISOString() +
-                            '" title="' + moment.unix(data).fromNow() + '">' +
-                            format_time(data) + '</time>';
+                            '">' + format_time(data) + '</time>';
                     }
                     return data;
                 }

--- a/flower/views/tasks.py
+++ b/flower/views/tasks.py
@@ -102,12 +102,19 @@ class TasksView(BaseHandler):
 
         if not app.options.browser_local_time:
             # Append Celery app timezone in IANA format
+
+            timezone = None
+
             if capp.timezone:
                 if isinstance(capp.timezone, LocalTimezone):
-                    timezone = get_localzone()
+                    try:
+                        timezone = get_localzone()
+                    except Exception as ex:
+                        logger.warning("Failed to retrieve local timezone (%s): %s", type(ex).__name__, ex)
                 else:
                     timezone = capp.timezone
-            else:
+
+            if timezone is None:
                 timezone = ZoneInfo("UTC")
 
             time = f'{time}-{timezone}'

--- a/flower/views/tasks.py
+++ b/flower/views/tasks.py
@@ -1,7 +1,10 @@
 import copy
 import logging
 
+import pytz
 from tornado import web
+from tzlocal import get_localzone
+from celery.utils.time import LocalTimezone
 
 from ..utils.search import QuerySyntaxError
 from ..utils.tasks import as_dict, get_task_by_id, search_tasks
@@ -96,8 +99,18 @@ class TasksView(BaseHandler):
         capp = self.application.capp
 
         time = 'natural-time' if app.options.natural_time else 'time'
-        if capp.conf.timezone:
-            time += '-' + str(capp.conf.timezone)
+
+        if not app.options.browser_local_time:
+            # Append Celery app timezone in IANA format
+            if capp.timezone:
+                if isinstance(capp.timezone, LocalTimezone):
+                    timezone = get_localzone()
+                else:
+                    timezone = capp.timezone
+            else:
+                timezone = pytz.utc
+
+            time = f'{time}-{timezone}'
 
         self.render(
             "tasks.html",

--- a/flower/views/tasks.py
+++ b/flower/views/tasks.py
@@ -1,7 +1,7 @@
 import copy
 import logging
+from zoneinfo import ZoneInfo
 
-import pytz
 from tornado import web
 from tzlocal import get_localzone
 from celery.utils.time import LocalTimezone
@@ -108,7 +108,7 @@ class TasksView(BaseHandler):
                 else:
                     timezone = capp.timezone
             else:
-                timezone = pytz.utc
+                timezone = ZoneInfo("UTC")
 
             time = f'{time}-{timezone}'
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -3,3 +3,4 @@ tornado>=6.5.7,<7.0.0
 prometheus_client>=0.8.0
 humanize
 pytz
+tzlocal

--- a/tests/unit/views/test_tasks.py
+++ b/tests/unit/views/test_tasks.py
@@ -406,4 +406,4 @@ class TasksTimeZoneTest(AsyncHTTPTestCase):
         r = self.get('/tasks')
         self.assertEqual(200, r.code)
         body = r.body.decode()
-        self.assertIn('time', body)
+        self.assertIn('value="time"', body)

--- a/tests/unit/views/test_tasks.py
+++ b/tests/unit/views/test_tasks.py
@@ -386,10 +386,17 @@ class TasksTimeZoneTest(AsyncHTTPTestCase):
         self._app.capp.conf.enable_utc = False
         self._app.options.browser_local_time = False
 
+        try:
+            expected_tz = get_localzone()
+        except Exception:
+            expected_tz = None
+        if expected_tz is None:
+            expected_tz = 'UTC'
+
         r = self.get('/tasks')
         self.assertEqual(200, r.code)
         body = r.body.decode()
-        self.assertIn(f'time-{get_localzone()}', body)
+        self.assertIn(f'time-{expected_tz}', body)
 
     def test_browser_local_time(self):
         del self._app.capp.timezone  # clear cached property

--- a/tests/unit/views/test_tasks.py
+++ b/tests/unit/views/test_tasks.py
@@ -2,6 +2,7 @@ import json
 import time
 
 from celery.events import Event
+from tzlocal import get_localzone
 
 from flower.events import EventsState
 from tests.unit import AsyncHTTPTestCase
@@ -343,3 +344,59 @@ class TasksTest(AsyncHTTPTestCase):
         self.assertEqual('task2', tasks[0]['name'])
         self.assertEqual('456', tasks[0]['uuid'])
         self.assertEqual('worker1', tasks[0]['worker'])
+
+
+class TasksTimeZoneTest(AsyncHTTPTestCase):
+
+    def test_config_time_zone_is_utc(self):
+        del self._app.capp.timezone  # clear cached property
+        self._app.capp.conf.timezone = 'UTC'
+        self._app.capp.conf.enable_utc = False  # should be ignored
+        self._app.options.browser_local_time = False
+
+        r = self.get('/tasks')
+        self.assertEqual(200, r.code)
+        body = r.body.decode()
+        self.assertIn('time-UTC', body)
+
+    def test_config_time_zone_is_celery_local(self):
+        del self._app.capp.timezone  # clear cached property
+        self._app.capp.conf.timezone = 'Pacific/Chatham'
+        self._app.capp.conf.enable_utc = True  # should be ignored
+        self._app.options.browser_local_time = False
+
+        r = self.get('/tasks')
+        self.assertEqual(200, r.code)
+        body = r.body.decode()
+
+        self.assertIn(f'time-Pacific/Chatham', body)
+
+    def test_default_time_zone_is_utc(self):
+        del self._app.capp.timezone  # clear cached property
+        self._app.capp.conf.enable_utc = True
+        self._app.options.browser_local_time = False
+
+        r = self.get('/tasks')
+        self.assertEqual(200, r.code)
+        body = r.body.decode()
+        self.assertIn('time-UTC', body)
+
+    def test_default_time_zone_is_system_local(self):
+        del self._app.capp.timezone  # clear cached property
+        self._app.capp.conf.enable_utc = False
+        self._app.options.browser_local_time = False
+
+        r = self.get('/tasks')
+        self.assertEqual(200, r.code)
+        body = r.body.decode()
+        self.assertIn(f'time-{get_localzone()}', body)
+
+    def test_browser_local_time(self):
+        del self._app.capp.timezone  # clear cached property
+        self._app.capp.conf.timezone = 'Pacific/Chatham'
+        self._app.options.browser_local_time = True
+
+        r = self.get('/tasks')
+        self.assertEqual(200, r.code)
+        body = r.body.decode()
+        self.assertIn(f'time', body)

--- a/tests/unit/views/test_tasks.py
+++ b/tests/unit/views/test_tasks.py
@@ -369,7 +369,7 @@ class TasksTimeZoneTest(AsyncHTTPTestCase):
         self.assertEqual(200, r.code)
         body = r.body.decode()
 
-        self.assertIn(f'time-Pacific/Chatham', body)
+        self.assertIn('time-Pacific/Chatham', body)
 
     def test_default_time_zone_is_utc(self):
         del self._app.capp.timezone  # clear cached property
@@ -399,4 +399,4 @@ class TasksTimeZoneTest(AsyncHTTPTestCase):
         r = self.get('/tasks')
         self.assertEqual(200, r.code)
         body = r.body.decode()
-        self.assertIn(f'time', body)
+        self.assertIn('time', body)


### PR DESCRIPTION
Closes #1132

## Changes

- Introduce the flower config parameter `browser_local_time` (bool) to show the time in the Celery app timezone or the browser local timezone.
- When using the Celery app timezone, respect the Celery option `enable_utc` (when Celery option `timezone` is missing the celery app uses UTC or the system TZ).
- The timezone is shown as a tooltip when hovering over the time.
- The full time + timezone is shown as a tooltip when hovering over the time when `natural_time=True`.

## Implementation

The task _started_ and _received_ times in the task table are derived from the raw celery events which provide times as number of seconds passed since the _epoch_. 

https://github.com/mher/flower/blob/58136bf26bb641082d31a376306b73ef5047b80f/flower/views/tasks.py#L117

This code takes `timezone` into account but not `enable_utc`.

https://docs.celeryq.dev/en/stable/userguide/configuration.html#time-and-date-settings

Instead of using the time and date settings from the celery configuration directly, this PR proposes to use the timezone provided by the celery app

https://github.com/celery/celery/blob/8f389997887232500d4aa1a2b0ae0c7320c4c84a/celery/app/base.py#L1360

This allows using an explicit timezone (e.g. `timezone = "Europe/Paris"`) or the local timezone (`enable_utc = False`).