### PR TITLE
feat: Added support for Azure Service Bus using docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:alpine
 RUN apk add --no-cache ca-certificates tzdata && update-ca-certificates
 
 # Install the required packages
-RUN pip install --no-cache-dir redis flower
+RUN pip install --no-cache-dir redis flower azure-identity azure-servicebus
 
 # PYTHONUNBUFFERED: Force stdin, stdout and stderr to be totally unbuffered. (equivalent to `python -u`)
 # PYTHONHASHSEED: Enable hash randomization (equivalent to `python -R`)


### PR DESCRIPTION
Flower docker image doesn't support Azure Service Bus out of the box. It means custom images have to be created in every case. There is unanswered question https://github.com/mher/flower/discussions/1317 as well. This change adds support for azure service bus.