### PR TITLE
Adding amqps as a valid broker scheme

### DIFF
--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -393,7 +393,7 @@ Return length of all active queues
         app = self.application
 
         http_api = None
-        if app.transport == 'amqp' and app.options.broker_api:
+        if (app.transport == 'amqp' or app.transport == 'amqps') and app.options.broker_api:
             http_api = app.options.broker_api
 
         broker = Broker(app.capp.connection().as_uri(include_password=True),

--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -230,6 +230,8 @@ class Broker:
         scheme = urlparse(broker_url).scheme
         if scheme == 'amqp':
             return RabbitMQ(broker_url, *args, **kwargs)
+        if scheme == 'amqps':
+            return RabbitMQ(broker_url, *args, **kwargs)
         if scheme == 'redis':
             return Redis(broker_url, *args, **kwargs)
         if scheme == 'rediss':

--- a/flower/views/broker.py
+++ b/flower/views/broker.py
@@ -14,7 +14,7 @@ class BrokerView(BaseHandler):
         app = self.application
 
         http_api = None
-        if app.transport == 'amqp' and app.options.broker_api:
+        if (app.transport == 'amqp' or app.transport == 'amqps') and app.options.broker_api:
             http_api = app.options.broker_api
 
         try:


### PR DESCRIPTION
Issue here: https://github.com/mher/flower/issues/1369

Flower does not take into account the `BROKER_API` config setting right now if the scheme is set to `amqps`. It errors.

This seems like it should not be the case, as there is no change required for the RabbitMQ API to work, regardless of amqp or amqps.