### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         celery-version: ['5.2.*', '5.3.*']
         tornado-version: ['6.0']
+        exclude:  # https://docs.celeryq.dev/en/v5.2.1/whatsnew-5.2.html#step-5-upgrade-to-celery-5-2
+          - python-version: '3.12'
+            celery-version: '5.2.*'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        celery-version: ['5.2', '5.3']
+        celery-version: ['5.2.x', '5.3.x']
         tornado-version: ['6.0']
 
     steps:
@@ -23,11 +24,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install celery==${{ matrix.celery-version }}
-        pip install tornado==${{ matrix.tornado-version }}
-        pip install -r requirements/default.txt
-        pip install -r requirements/test.txt
-        pip install -r requirements/dev.txt
+        pip install celery==${{ matrix.celery-version }} \
+                    tornado==${{ matrix.tornado-version }} \
+                    -r requirements/default.txt \
+                    -r requirements/test.txt \
+                    -r requirements/dev.txt
 
     - name: Lint with pylint
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install celery==${{ matrix.celery-version }} \
                     tornado==${{ matrix.tornado-version }} \
-                    -r requirements/default.txt \
-                    -r requirements/test.txt \
                     -r requirements/dev.txt
 
     - name: Lint with pylint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        celery-version: ['5.2.x', '5.3.x']
+        celery-version: ['5.2.*', '5.3.*']
         tornado-version: ['6.0']
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install celery==${{ matrix.celery-version }} \
-                    tornado==${{ matrix.tornado-version }} \
-                    -r requirements/default.txt \
-                    -r requirements/test.txt \
+        pip install celery==${{ matrix.celery-version }}
+                    tornado==${{ matrix.tornado-version }}
+                    -r requirements/default.txt
+                    -r requirements/test.txt
                     -r requirements/dev.txt
 
     - name: Lint with pylint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install celery==${{ matrix.celery-version }}
-                    tornado==${{ matrix.tornado-version }}
-                    -r requirements/default.txt
-                    -r requirements/test.txt
+        pip install celery==${{ matrix.celery-version }} \
+                    tornado==${{ matrix.tornado-version }} \
+                    -r requirements/default.txt \
+                    -r requirements/test.txt \
                     -r requirements/dev.txt
 
     - name: Lint with pylint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,17 +10,17 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        celery-version: ['5.2.*', '5.3.*']
+        celery-version: ['5.2.*', '5.3.*', '5.4.*']
         tornado-version: ['6.0']
-        exclude:  # https://docs.celeryq.dev/en/v5.2.1/whatsnew-5.2.html#step-5-upgrade-to-celery-5-2
+        exclude:  # https://docs.celeryq.dev/en/v5.2.7/whatsnew-5.2.html#step-5-upgrade-to-celery-5-2
           - python-version: '3.12'
             celery-version: '5.2.*'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -33,7 +33,7 @@ jobs:
 
     - name: Lint with pylint
       run: |
-        pylint flower  --rcfile .pylintrc
+        pylint flower --rcfile .pylintrc
 
     - name: Run unit tests
       run: |

--- a/flower/utils/tasks.py
+++ b/flower/utils/tasks.py
@@ -56,11 +56,10 @@ def sort_tasks(tasks, sort_by):
     if sort_by.startswith('-'):
         sort_by = sort_by.lstrip('-')
         reverse = True
-    for task in sorted(
+    yield from sorted(
             tasks,
             key=lambda x: getattr(x[1], sort_by) or sort_keys[sort_by](),
-            reverse=reverse):
-        yield task
+            reverse=reverse)
 
 
 def get_task_by_id(events, task_id):


### PR DESCRIPTION
Automates the process of creating pull requests like:
* #1147
* #1292

Fixes warnings like at the bottom right of https://github.com/mher/flower/actions/runs/9844246249

---

* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the dependabot.yml file - package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)

* Modern pip has a real dependency resolver so give it all requirements at once
* Fix pylint issue https://docs.astral.sh/ruff/rules/yield-in-for-loop
* `celery-version: ['5.2.*', '5.3.*', '5.4.*']`
* Celery 5.2 does not support Python 3.12
    * https://docs.celeryq.dev/en/stable/history/whatsnew-5.3.html