### PR TITLE
Add support for storing state in Redis

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -340,6 +340,7 @@ Enables persistent mode in Flower.
 When persistent mode is enabled, Flower saves its current state and reloads it upon restart.
 This ensures that Flower retains its state and configuration across restarts.
 Flower stores its state in a database file specified by the `db`_ option.
+If `db` starts with `redis://`, Flower will use Redis as a backend for storing its state.
 
 .. _port:
 


### PR DESCRIPTION
This pull request introduces support for storing the persistent state of Flower in Redis, as an alternative to the existing file-based storage mechanism. This enhancement aims to improve the reliability, scalability, and performance of state management in Flower. 

This removes the limitation that prevented running multiple instances of Flower concurrently by centralizing state management in Redis.