### PR TITLE
print_banner: print actual port in case the port is dynamic

### DIFF
--- a/tests/unit/api/test_control.py
+++ b/tests/unit/api/test_control.py
@@ -16,12 +16,12 @@ class UnknownWorkerControlTests(BaseApiTestCase):
 
 class WorkerControlTests(BaseApiTestCase):
     def setUp(self):
-        BaseApiTestCase.setUp(self)
+        super().setUp()
         self.is_worker = ControlHandler.is_worker
         ControlHandler.is_worker = lambda *args: True
 
     def tearDown(self):
-        BaseApiTestCase.tearDown(self)
+        super().tearDown()
         ControlHandler.is_worker = self.is_worker
 
     def test_shutdown(self):

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -97,12 +97,6 @@ class MockTasks:
 
 
 class TaskTests(BaseApiTestCase):
-    def setUp(self):
-        self.app = super().get_app()
-        super().setUp()
-
-    def get_app(self, capp=None):
-        return self.app
 
     @patch('flower.api.tasks.tasks', new=MockTasks)
     def test_task_info(self):
@@ -127,7 +121,7 @@ class TaskTests(BaseApiTestCase):
             e['clock'] = i
             e['local_received'] = time.time()
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         # Test limit 4 and offset 0
         params = dict(limit=4, offset=0, sort_by='name')

--- a/tests/unit/views/test_monitor.py
+++ b/tests/unit/views/test_monitor.py
@@ -11,12 +11,6 @@ from tests.unit.utils import task_failed_events, task_succeeded_events
 
 
 class PrometheusTests(AsyncHTTPTestCase):
-    def setUp(self):
-        self.app = super().get_app()
-        super().setUp()
-
-    def get_app(self, capp=None):
-        return self.app
 
     def test_metrics(self):
         state = EventsState()
@@ -32,7 +26,7 @@ class PrometheusTests(AsyncHTTPTestCase):
             e['clock'] = i
             e['local_received'] = time.time()
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         metrics = self.get('/metrics').body.decode('utf-8')
         events = dict(re.findall('flower_events_total{task="task1",type="(task-.*)",worker="worker1"} (.*)', metrics))
@@ -61,7 +55,7 @@ class PrometheusTests(AsyncHTTPTestCase):
             if e['type'] == 'task-started':
                 e['timestamp'] = task_started
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         metrics = self.get('/metrics').body.decode('utf-8')
 
@@ -86,7 +80,7 @@ class PrometheusTests(AsyncHTTPTestCase):
             if e['type'] == 'task-started':
                 e['timestamp'] = task_started
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         metrics = self.get('/metrics').body.decode('utf-8')
 
@@ -111,7 +105,7 @@ class PrometheusTests(AsyncHTTPTestCase):
             if e['type'] == 'task-started':
                 e['timestamp'] = task_started
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         metrics = self.get('/metrics').body.decode('utf-8')
 
@@ -132,7 +126,7 @@ class PrometheusTests(AsyncHTTPTestCase):
             e['clock'] = i
             e['local_received'] = time.time()
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         metrics = self.get('/metrics').body.decode('utf-8')
 
@@ -149,7 +143,7 @@ class PrometheusTests(AsyncHTTPTestCase):
             e['clock'] = i
             e['local_received'] = time.time()
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         metrics = self.get('/metrics').body.decode('utf-8')
 
@@ -189,7 +183,7 @@ class PrometheusTests(AsyncHTTPTestCase):
             e['clock'] = i
             e['local_received'] = time.time()
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         metrics = self.get('/metrics').body.decode('utf-8')
 
@@ -199,12 +193,6 @@ class PrometheusTests(AsyncHTTPTestCase):
 
 
 class HealthcheckTests(AsyncHTTPTestCase):
-    def setUp(self):
-        self.app = super().get_app()
-        super().setUp()
-
-    def get_app(self, capp=None):
-        return self.app
 
     def test_healthcheck_route(self):
         response = self.get('/healthcheck').body.decode('utf-8')

--- a/tests/unit/views/test_tasks.py
+++ b/tests/unit/views/test_tasks.py
@@ -16,12 +16,6 @@ class TaskTest(AsyncHTTPTestCase):
 
 
 class TasksTest(AsyncHTTPTestCase):
-    def setUp(self):
-        self.app = super().get_app()
-        super().setUp()
-
-    def get_app(self, capp=None):
-        return self.app
 
     def test_no_task(self):
         r = self.get('/tasks')
@@ -39,7 +33,7 @@ class TasksTest(AsyncHTTPTestCase):
             e['clock'] = i
             e['local_received'] = time.time()
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         params = dict(draw=1, start=0, length=10)
         params['search[value]'] = ''
@@ -71,7 +65,7 @@ class TasksTest(AsyncHTTPTestCase):
             e['clock'] = i
             e['local_received'] = time.time()
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         params = dict(draw=1, start=0, length=10)
         params['search[value]'] = ''
@@ -109,7 +103,7 @@ class TasksTest(AsyncHTTPTestCase):
             e['clock'] = i
             e['local_received'] = time.time()
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         params = dict(draw=1, start=0, length=10)
         params['search[value]'] = ''
@@ -157,7 +151,7 @@ class TasksTest(AsyncHTTPTestCase):
             e['clock'] = i
             e['local_received'] = time.time()
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         params = dict(draw=1, start=0, length=10)
         params['search[value]'] = ''
@@ -198,7 +192,7 @@ class TasksTest(AsyncHTTPTestCase):
             e['clock'] = i
             e['local_received'] = time.time()
             state.event(e)
-        self.app.events.state = state
+        self._app.events.state = state
 
         params = dict(draw=1, start=0, length=10)
         params['search[value]'] = ''

--- a/tests/unit/views/test_workers.py
+++ b/tests/unit/views/test_workers.py
@@ -13,12 +13,6 @@ from tests.unit.utils import (HtmlTableParser, task_failed_events,
 
 
 class WorkersTests(AsyncHTTPTestCase):
-    def setUp(self):
-        self.app = super().get_app()
-        super().setUp()
-
-    def get_app(self, capp=None):
-        return self.app
 
     def test_default_page(self):
         r1 = self.get('/')
@@ -45,7 +39,7 @@ class WorkersTests(AsyncHTTPTestCase):
                           local_received=time.time()))
         state.event(Event('worker-offline', hostname='worker1',
                           local_received=time.time()))
-        self.app.events.state = state
+        self._app.events.state = state
 
         r = self.get('/workers')
         table = HtmlTableParser()
@@ -65,7 +59,7 @@ class WorkersTests(AsyncHTTPTestCase):
                           local_received=time.time()))
         state.event(Event('worker-offline', hostname='worker1',
                           local_received=time.time()))
-        self.app.events.state = state
+        self._app.events.state = state
 
         with patch('flower.views.workers.options') as mock_options:
             mock_options.purge_offline_workers = 0
@@ -82,7 +76,7 @@ class WorkersTests(AsyncHTTPTestCase):
         state.get_or_create_worker('worker1')
         state.event(Event('worker-online', hostname='worker1',
                           local_received=time.time()))
-        self.app.events.state = state
+        self._app.events.state = state
 
         r = self.get('/workers')
 
@@ -110,7 +104,7 @@ class WorkersTests(AsyncHTTPTestCase):
             e['local_received'] = time.time()
             state.event(e)
 
-        self.app.events.state = state
+        self._app.events.state = state
 
         r = self.get('/workers')
 
@@ -140,7 +134,7 @@ class WorkersTests(AsyncHTTPTestCase):
             e['local_received'] = time.time()
             state.event(e)
 
-        self.app.events.state = state
+        self._app.events.state = state
 
         r = self.get('/workers')
 
@@ -172,7 +166,7 @@ class WorkersTests(AsyncHTTPTestCase):
             e['local_received'] = time.time()
             state.event(e)
 
-        self.app.events.state = state
+        self._app.events.state = state
 
         r = self.get('/workers')
 
@@ -204,7 +198,7 @@ class WorkersTests(AsyncHTTPTestCase):
             e['local_received'] = time.time()
             state.event(e)
 
-        self.app.events.state = state
+        self._app.events.state = state
 
         r = self.get('/workers')
 
@@ -238,7 +232,7 @@ class WorkersTests(AsyncHTTPTestCase):
             e['local_received'] = time.time()
             state.event(e)
 
-        self.app.events.state = state
+        self._app.events.state = state
 
         r = self.get('/workers')
 
@@ -271,7 +265,7 @@ class WorkersTests(AsyncHTTPTestCase):
             e['local_received'] = time.time()
             state.event(e)
 
-        self.app.events.state = state
+        self._app.events.state = state
 
         r = self.get('/workers')
 
@@ -293,7 +287,7 @@ class WorkersTests(AsyncHTTPTestCase):
         state.get_or_create_worker('worker1')
         state.event(Event('worker-online', hostname='worker1',
                           local_received=time.time()))
-        self.app.events.state = state
+        self._app.events.state = state
 
         res = self.get('/workers?json=1')
         self.assertEqual(200, res.code)
@@ -305,9 +299,9 @@ class WorkersTests(AsyncHTTPTestCase):
         state.get_or_create_worker('worker1')
         state.event(Event('worker-online', hostname='worker1',
                           local_received=time.time()))
-        self.app.events.state = state
+        self._app.events.state = state
 
-        with patch.object(self.get_app(), "update_workers") as update_workers_mock:
+        with patch.object(self._app, "update_workers") as update_workers_mock:
             res = self.get('/workers?refresh=1')
             self.assertEqual(200, res.code)
             update_workers_mock.assert_called()
@@ -317,17 +311,17 @@ class WorkersTests(AsyncHTTPTestCase):
         state.get_or_create_worker('worker1')
         state.event(Event('worker-online', hostname='worker1',
                           local_received=time.time()))
-        self.app.events.state = state
-        self.app.inspector.workers['worker1'] = {'registeres': [], 'active_queues': [],
+        self._app.events.state = state
+        self._app.inspector.workers['worker1'] = {'registeres': [], 'active_queues': [],
                                                  'stats': {'total': {'tasks.add': 10, 'tasks.sleep': 1, 'tasks.error': 1},
                                                            'broker': {'hostname': 'redis', 'userid': None, 'virtual_host': '/', 'port': 6379}}}
 
-        with patch.object(self.get_app(), "update_workers") as update_workers_mock:
+        with patch.object(self._app, "update_workers") as update_workers_mock:
             res = self.get('/worker/worker1')
             self.assertEqual(200, res.code)
             update_workers_mock.assert_called_once_with(workername='worker1')
 
-        with patch.object(self.get_app(), "update_workers") as update_workers_mock:
+        with patch.object(self._app, "update_workers") as update_workers_mock:
             res = self.get('/worker/worker2')
             self.assertEqual(404, res.code)
             update_workers_mock.assert_called_once_with(workername='worker2')


### PR DESCRIPTION
Closes #1449

When starting flower with `--port=0` the port is dynamically assigned but `print_banner` shows `Visit me at http://0.0.0.0:0`.

- Fix by passing the flower app to `print_banner` instead of the celery app.
- For this to work we need to decouple the start of the server and the start of the event loop. We know the port only after the server was started. In addition the event loop might need to be controlled outside of this class. In the unit test framework for example. So the decoupling is useful for that as well.
- For backward compatibility the coupled start method is kept (same for stop)
    ```python
    class Flower(tornado.web.Application):
        ...
        def start(self):  # for backward compatibility
            self.start_server()
            self.update_workers()
            self.serve_forever()
    ```
- To add a unit test for the dynamic port showing up in the banner, the `AsyncHTTPTestCase` base class needs to be in charge of creating the HTTP server. Before it was `tornado.testing.AsyncHTTPTestCase` doing this. Now we derive from `tornado.testing.AsyncTestCase` and let `Flower` handle the HTTP server. This happens in production anyway so now we cover that as well. In addition this makes the usage in other tests much cleaner.