### PR TITLE
Support prometheus multiprocess collector

### DIFF
--- a/flower/views/monitor.py
+++ b/flower/views/monitor.py
@@ -1,11 +1,22 @@
-import prometheus_client
+import os
+
+import prometheus_client.multiprocess
 
 from ..views import BaseHandler
 
 
 class Metrics(BaseHandler):
+    def _get_registry(self):
+        if not ("PROMETHEUS_MULTIPROC_DIR" in os.environ
+                or "prometheus_multiproc_dir" in os.environ):
+            return prometheus_client.REGISTRY
+
+        registry = prometheus_client.CollectorRegistry()
+        prometheus_client.multiprocess.MultiProcessCollector(registry)
+        return registry
+
     async def get(self):
-        self.write(prometheus_client.generate_latest())
+        self.write(prometheus_client.generate_latest(self._get_registry()))
         self.set_header("Content-Type", "text/plain")
 
 


### PR DESCRIPTION
Current prometheus integration does not support custom metrics reporting.
Let's we have following code in `sample.py`:
```python
import celery
import prometheus_client


app = celery.Celery(
    'app',
    broker='redis://localhost:6379/0',
    result_backend='redis://localhost:6379/0',
)


gauge = prometheus_client.Gauge('my_gauge', '')


@app.task
def my_task(x):
    gauge.set(int(x))
    return x
```

Then we run celery:
```bash
(venv) $ celery -A sample worker
```

And flower:
```bash
(venv) $ FLOWER_UNAUTHENTICATED_API=1 celery -A sample flower --port=5000
```

After send task `my_task` gauge doesn't change:
```bash
$ curl -sH 'Content-Type: application/json' -o /dev/null -d '{"args": [3]}' 'http://localhost:5000/api/task/apply/sample.my_task'
$ curl -s http://localhost:5000/metrics | grep my_gauge
# HELP my_gauge 
# TYPE my_gauge gauge
my_gauge 0.0
```

If we set `PROMETHEUS_MULTIPROC_DIR=/tmp/pmp` nothing changes:
```bash
$ curl -sH 'Content-Type: application/json' -o /dev/null -d '{"args": [3]}' 'http://localhost:5000/api/task/apply/sample.my_task'
$ curl -s http://localhost:5000/metrics | grep my_gauge
# HELP my_gauge 
# TYPE my_gauge gauge
my_gauge{pid="1256424"} 0.0
my_gauge{pid="1256439"} 0.0
```

After applying fix from this PR gauge changed (we must run celery and flower with `PROMETHEUS_MULTIPROC_DIR` environment variable):
```bash
$ curl -sH 'Content-Type: application/json' -o /dev/null -d '{"args": [3]}' 'http://localhost:5000/api/task/apply/sample.my_task'
$ curl -s http://localhost:5000/metrics | grep my_gauge
# HELP my_gauge 
# TYPE my_gauge gauge
my_gauge{pid="1256426"} 3.0
my_gauge{pid="1256424"} 0.0
my_gauge{pid="1256439"} 0.0
```