### PR TITLE
feature: state filtering + dark theme

### DIFF
--- a/flower/static/css/flower.css
+++ b/flower/static/css/flower.css
@@ -39,3 +39,248 @@ div.dataTables_wrapper .dataTables_filter input {
 .overflow-auto::-webkit-scrollbar {
   display: none;
 }
+
+:root[data-bs-theme='dark'] {
+  color-scheme: dark;
+}
+
+:root[data-bs-theme='dark'] .bg-green {
+  background-color: #18301e;
+}
+
+:root[data-bs-theme='dark'] .dropdown-menu,
+:root[data-bs-theme='dark'] .form-control,
+:root[data-bs-theme='dark'] .btn,
+:root[data-bs-theme='dark'] .page-link {
+  background-color: #121212;
+  color: #e2e2e2;
+}
+
+:root[data-bs-theme='dark'] body {
+  background-color: #121212;
+  color: #e2e2e2;
+}
+
+:root[data-bs-theme='dark'] .table {
+  color: #e2e2e2;
+  --bs-table-bg: transparent;
+  --bs-table-striped-bg: transparent;
+  --bs-table-striped-color: #e2e2e2;
+  --bs-table-hover-bg: rgba(255, 255, 255, 0.075);
+  --bs-table-hover-color: #e2e2e2;
+}
+
+:root[data-bs-theme='dark'] .table thead th {
+  background-color: #1a1f1a;
+  color: #e2e2e2;
+  border-color: #444;
+}
+
+:root[data-bs-theme='dark'] .table-striped > tbody > tr:nth-of-type(odd) > * {
+  background-color: #151a15 !important; /* subtle deep green tint */
+  color: #e2e2e2 !important;
+}
+
+:root[data-bs-theme='dark'] .table-striped > tbody > tr:nth-of-type(even) > * {
+  background-color: #111411 !important; /* base row color */
+  color: #e2e2e2 !important;
+}
+
+:root[data-bs-theme='dark'] .dataTables_wrapper {
+  background-color: transparent !important;
+  border-color: #2f3c2a;
+}
+
+:root[data-bs-theme='dark'] .dataTables_wrapper .dataTables_info,
+:root[data-bs-theme='dark'] .dataTables_wrapper .dataTables_length label,
+:root[data-bs-theme='dark'] .dataTables_wrapper .dataTables_filter label {
+  color: #cfcfcf;
+}
+
+:root[data-bs-theme='dark'] div.dataTables_wrapper .dataTables_filter input {
+  background-color: #1f1f1f;
+  color: #e2e2e2;
+  border: 1px solid #2f3c2a;
+}
+
+:root[data-bs-theme='dark'] .btn-outline-secondary,
+:root[data-bs-theme='dark'] .btn-outline-success,
+:root[data-bs-theme='dark'] .btn-outline-danger,
+:root[data-bs-theme='dark'] .btn-outline-primary,
+:root[data-bs-theme='dark'] .btn-outline-warning,
+:root[data-bs-theme='dark'] .btn-outline-dark,
+:root[data-bs-theme='dark'] .btn-outline-info {
+  color: #e2e2e2;
+  border-color: #3b3b3b;
+}
+
+:root[data-bs-theme='dark'] .btn-outline-secondary:hover,
+:root[data-bs-theme='dark'] .btn-outline-success:hover,
+:root[data-bs-theme='dark'] .btn-outline-danger:hover,
+:root[data-bs-theme='dark'] .btn-outline-primary:hover,
+:root[data-bs-theme='dark'] .btn-outline-warning:hover,
+:root[data-bs-theme='dark'] .btn-outline-dark:hover,
+:root[data-bs-theme='dark'] .btn-outline-info:hover {
+  background-color: #2a2a2a;
+}
+
+:root[data-bs-theme='dark'] a,
+:root[data-bs-theme='dark'] .nav-link,
+:root[data-bs-theme='dark'] .page-link {
+  color: #cde4ff;
+}
+
+:root[data-bs-theme='dark'] .dropdown-menu {
+  background-color: #1a1a1a;
+  border-color: #333;
+}
+
+:root[data-bs-theme='dark'] .dropdown-item {
+  color: #e2e2e2;
+}
+
+:root[data-bs-theme='dark'] .dropdown-item:hover {
+  background-color: #2a2a2a;
+}
+
+:root[data-bs-theme='dark'] .dataTables_wrapper .dataTables_paginate .paginate_button {
+  color: #e2e2e2 !important;
+  border: 1px solid #333 !important;
+  background: #1a1a1a !important;
+}
+
+:root[data-bs-theme='dark'] .dataTables_wrapper .dataTables_paginate .paginate_button.current,
+:root[data-bs-theme='dark'] .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
+  color: #fff !important;
+  background: #2a2a2a !important;
+}
+
+:root[data-bs-theme='dark'] .navbar {
+  background-color: #18301e !important;
+}
+
+:root[data-bs-theme='dark'] .navbar .navbar-brand,
+:root[data-bs-theme='dark'] .navbar .nav-link {
+  color: #e2e2e2 !important;
+}
+
+:root[data-bs-theme='dark'] .navbar .nav-link:hover {
+  color: #fff !important;
+}
+
+:root[data-bs-theme='dark'] .nav-tabs {
+  border-bottom: 1px solid #2f3c2a;
+}
+
+:root[data-bs-theme='dark'] .nav-tabs .nav-link {
+  color: #e2e2e2;
+  border: 1px solid transparent;
+  background-color: transparent;
+}
+
+:root[data-bs-theme='dark'] .nav-tabs .nav-link:hover {
+  color: #fff;
+  background-color: #111411;
+  border-color: #2f3c2a #2f3c2a #2f3c2a;
+}
+
+:root[data-bs-theme='dark'] .nav-tabs .nav-link.active,
+:root[data-bs-theme='dark'] .nav-tabs .nav-item.show .nav-link {
+  color: #fff;
+  background-color: #18301e;
+  border-color: #2f3c2a #2f3c2a transparent;
+}
+
+:root[data-bs-theme='dark'] .table tbody tr {
+  background-color: transparent !important;
+}
+
+:root[data-bs-theme='dark'] .table tbody td {
+  background-color: transparent !important;
+  color: #e2e2e2 !important;
+  border-color: #444 !important;
+}
+
+:root[data-bs-theme='dark'] .table tbody tr:hover td {
+  background-color: rgba(255, 255, 255, 0.075) !important;
+}
+
+:root[data-bs-theme='dark'] table.dataTable tbody tr {
+  background-color: transparent !important;
+}
+
+:root[data-bs-theme='dark'] table.dataTable tbody td {
+  background-color: transparent !important;
+}
+
+:root[data-bs-theme='dark'] .dataTables_empty {
+  background-color: #151a15 !important;
+  color: #e2e2e2 !important;
+}
+
+#tasks-table_filter {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+#tasks-table_filter label {
+  margin-bottom: 0;
+}
+
+.state-filter-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.state-filter-label {
+  font-size: 0.875rem;
+  color: #6c757d;
+}
+
+:root[data-bs-theme='dark'] .state-filter-label {
+  color: #adb5bd;
+}
+
+.status-filter-dropdown .dropdown-menu {
+  min-width: 210px;
+  max-width: 260px;
+  max-height: 420px;
+  overflow-y: auto;
+  z-index: 1061;
+  padding: 0.75rem 1rem;
+}
+
+.status-filter-option {
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+}
+
+.status-filter-checkbox {
+  flex: 0 0 auto;
+  margin: 0;
+}
+
+.status-filter-option-label {
+  flex: 1 1 auto;
+  margin: 0;
+}
+
+div.dataTables_wrapper .dataTables_filter .status-filter-options > .status-filter-option > input[type="checkbox"] {
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  min-height: 20px;
+  margin: 0;
+}
+
+.status-filter-option-label {
+  flex: 1;
+}
+
+.status-filter-option .status-only {
+  font-size: 0.75rem;
+  flex: 0 0 auto;
+}

--- a/flower/templates/navbar.html
+++ b/flower/templates/navbar.html
@@ -25,6 +25,18 @@
     </ul>
 
     <ul class="navbar-nav flex-row flex-wrap ms-md-auto">
+      <li class="nav-item col-6 col-lg-auto me-2 d-flex align-items-center">
+        <div class="dropdown">
+          <button class="btn btn-outline-secondary btn-sm dropdown-toggle align-middle" type="button" id="themeDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+            Theme
+          </button>
+          <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="themeDropdown">
+            <li><button type="button" class="dropdown-item theme-choice" data-theme="system">System</button></li>
+            <li><button type="button" class="dropdown-item theme-choice" data-theme="light">Light</button></li>
+            <li><button type="button" class="dropdown-item theme-choice" data-theme="dark">Dark</button></li>
+          </ul>
+        </div>
+      </li>
       <li class="nav-item col-6 col-lg-auto">
         <a class="nav-link py-2 px-0 px-lg-2" href="https://github.com/mher/flower" target="_blank" rel="noopener">
           <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" class="navbar-nav-svg" viewBox="0 0 512 499.36"

--- a/flower/templates/tasks.html
+++ b/flower/templates/tasks.html
@@ -9,6 +9,31 @@
 <input type="hidden" value="{{ time }}" id='time'>
 <input type="hidden" value="{{ columns }}" id='columns'>
 
+<div id="state-filter-control" class="d-none">
+  <div class="state-filter-wrapper">
+    <span class="state-filter-label">Filter by state:</span>
+    <div class="dropdown state-filter-dropdown" data-bs-auto-close="outside">
+      <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button"
+              id="status-filter-toggle" data-bs-toggle="dropdown" aria-expanded="false"
+              aria-haspopup="true">
+        All
+      </button>
+      <div class="dropdown-menu dropdown-menu-end p-3" aria-labelledby="status-filter-toggle">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <span class="small fw-semibold">Filter states</span>
+          <div class="btn-group btn-group-sm" role="group" aria-label="State quick actions">
+            <button type="button" class="btn btn-link px-1 status-select-all">All</button>
+            <button type="button" class="btn btn-link px-1 status-select-none">None</button>
+          </div>
+        </div>
+        <div id="status-filter-options" class="status-filter-options" role="group" aria-label="Available task states">
+          <!-- populated by flower.js -->
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <div class="container-fluid mt-3">
   <table id="tasks-table" class="table table-bordered table-striped table-hover w-100">
     <thead>


### PR DESCRIPTION
<img width="1840" height="1098" alt="dark_theme" src="https://github.com/user-attachments/assets/186640b4-fc43-4ce7-b916-7ec38db665c3" />

- Adds a compact “Filter by state” dropdown next to the Tasks search box, wiring its selections through the existing datatable state-saving so toggles persist across reloads.
- Introduces an accessible theme switcher in the navbar
