### PR TITLE
Removed the JSON format of the args and kwargs strings in task page.

### DIFF
--- a/flower/templates/task.html
+++ b/flower/templates/task.html
@@ -45,11 +45,11 @@
               </tr>
               <tr>
                 <td>args</td>
-                <td>{{ task.args }}</td>
+                <td><pre>{{ task.args.replace(', ', ',\n').replace('[', '').replace(']', '').replace('(', '').replace(')', '') }}</pre></td>
               </tr>
               <tr>
                 <td>kwargs</td>
-                <td>{{ task.kwargs }}</td>
+                <td><pre>{{ task.kwargs.replace('{', '').replace('}', '').replace(', ', '\n').replace('\'', '') }}</pre></td>
               </tr>
               <tr>
                 <td>Result</td>


### PR DESCRIPTION
The details of args and kwargs are a single line in a JSON format, and that may confuse others when reading trying to read the contents of the args and kwargs. Therefore, this pull-request changed the format of the string to present the contents of args and kwargs in a more readable manner.