### PR TITLE
Upgrade OpenSSL in Dockerfile to Address Multiple CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:alpine
 
-# Get latest root certificates
-RUN apk add --no-cache ca-certificates tzdata && update-ca-certificates
+# Get latest root certificates and update openssl to fix vulnerabilities
+RUN apk add --no-cache ca-certificates tzdata && \
+    apk upgrade --no-cache openssl && \
+    update-ca-certificates
 
 # Install the required packages
 RUN pip install --no-cache-dir redis flower


### PR DESCRIPTION
## Description

This pull request updates the Dockerfile to ensure OpenSSL is upgraded to version **3.5.5-r0**, addressing several security vulnerabilities present in earlier versions (3.5.1-r0 and 3.5.4-r0). The following CVEs are remediated by this update:

### Critical
- **CVE-2025-15467**

### High
- **CVE-2025-69420**
- **CVE-2025-9230**

### Medium
- **CVE-2025-69419**
- **CVE-2025-9231**
- **CVE-2025-11187**
- **CVE-2025-66199**
- **CVE-2025-15468**
- **CVE-2025-9232**
- **CVE-2026-22795**
- **CVE-2025-15469**
- **CVE-2026-22796**
- **CVE-2025-68160**

### Low
- **CVE-2025-69418**
- **CVE-2025-69421**

---

### Summary of Changes

- Ensures the latest OpenSSL (**3.5.5-r0**) is installed via `apk upgrade --no-cache openssl`.
- Keeps the base image and root certificates up-to-date.
- Applies best practices for container security.

### Impact

- Resolves vulnerabilities that could lead to memory corruption, DoS, or information disclosure.
- No changes to application logic or runtime behavior.

---

Please review and merge to keep the container image secure.