### PR TITLE
Fix connection leaks in broker and transport access

### DIFF
--- a/flower/api/tasks.py
+++ b/flower/api/tasks.py
@@ -396,7 +396,9 @@ Return length of all active queues
         if app.transport == 'amqp' and app.options.broker_api:
             http_api = app.options.broker_api
 
-        broker = Broker(app.capp.connection().as_uri(include_password=True),
+        with app.capp.connection() as conn:
+            broker_uri = conn.as_uri(include_password=True)
+        broker = Broker(broker_uri,
                         http_api=http_api, broker_options=self.capp.conf.broker_transport_options,
                         broker_use_ssl=self.capp.conf.broker_use_ssl)
 

--- a/flower/app.py
+++ b/flower/app.py
@@ -64,6 +64,7 @@ class Flower(tornado.web.Application):
             max_workers_in_memory=self.options.max_workers,
             max_tasks_in_memory=self.options.max_tasks)
         self.started = False
+        self._transport = None
 
     def start(self):
         self.events.start()
@@ -93,7 +94,10 @@ class Flower(tornado.web.Application):
 
     @property
     def transport(self):
-        return getattr(self.capp.connection().transport, 'driver_type', None)
+        if self._transport is None:
+            with self.capp.connection() as conn:
+                self._transport = getattr(conn.transport, 'driver_type', None)
+        return self._transport
 
     @property
     def workers(self):

--- a/flower/command.py
+++ b/flower/command.py
@@ -173,7 +173,8 @@ def print_banner(app, ssl):
     else:
         logger.info("Visit me via unix socket file: %s", options.unix_socket)
 
-    logger.info('Broker: %s', app.connection().as_uri())
+    with app.connection() as conn:
+        logger.info('Broker: %s', conn.as_uri())
     logger.info(
         'Registered tasks: \n%s',
         pformat(sorted(app.tasks.keys()))

--- a/flower/views/broker.py
+++ b/flower/views/broker.py
@@ -17,8 +17,12 @@ class BrokerView(BaseHandler):
         if app.transport == 'amqp' and app.options.broker_api:
             http_api = app.options.broker_api
 
+        with app.capp.connection(connect_timeout=1.0) as conn:
+            broker_uri = conn.as_uri(include_password=True)
+            broker_url = conn.as_uri()
+
         try:
-            broker = Broker(app.capp.connection(connect_timeout=1.0).as_uri(include_password=True),
+            broker = Broker(broker_uri,
                             http_api=http_api, broker_options=self.capp.conf.broker_transport_options,
                             broker_use_ssl=self.capp.conf.broker_use_ssl)
         except NotImplementedError as exc:
@@ -31,5 +35,5 @@ class BrokerView(BaseHandler):
             logger.error("Unable to get queues: '%s'", e)
 
         self.render("broker.html",
-                    broker_url=app.capp.connection().as_uri(),
+                    broker_url=broker_url,
                     queues=queues)

--- a/flower/views/workers.py
+++ b/flower/views/workers.py
@@ -69,9 +69,11 @@ class WorkersView(BaseHandler):
         if json:
             self.write(dict(data=list(workers.values())))
         else:
+            with self.application.capp.connection() as conn:
+                broker_url = conn.as_uri()
             self.render("workers.html",
                         workers=workers,
-                        broker=self.application.capp.connection().as_uri(),
+                        broker=broker_url,
                         autorefresh=1 if self.application.options.auto_refresh else 0)
 
     @classmethod


### PR DESCRIPTION
## Summary

Several places call `capp.connection()` without using a context manager, creating AMQP/Redis connections that are never closed. Each leaked connection holds open a socket and file descriptor. Under sustained use (e.g. the Broker view refreshing, or `/api/queues/length` being polled by monitoring), this causes gradual file descriptor exhaustion, eventually leading to `Too many open files` errors that crash the process.

## Leaks fixed

| Location | Problem | Fix |
|---|---|---|
| `Flower.transport` property | Called on every request that checks broker type. Opens connection, reads driver type, discards without closing. | Cache the result (transport type never changes at runtime) + context manager for initial lookup |
| `print_banner()` | `app.connection().as_uri()` opens a connection to format the broker URL for the startup log. Never closed. | Context manager |
| `BrokerView.get()` | Two separate `capp.connection()` calls — one for Broker creation, one for display URL. Neither closed. | Single context-managed connection for both |
| `GetQueueLengths.get()` | `capp.connection().as_uri()` opens a connection to get broker URI. Never closed. | Context manager |
| `WorkersView.get()` | `capp.connection().as_uri()` opens a connection on every non-JSON page render. Never closed. | Context manager |

## Test plan

- [x] Verify existing tests pass — no behavioral change, only resource management
- [x] In long-running deployment, confirm no file descriptor growth over time (`lsof -p <pid> | wc -l`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)