### PR TITLE
fix: TaskTimout and TaskRateLimit should pass workername to error_reason

### DIFF
--- a/flower/api/control.py
+++ b/flower/api/control.py
@@ -470,7 +470,7 @@ Change soft and hard time limits for a task
         else:
             logger.error(response)
             self.set_status(403)
-            reason = self.error_reason(taskname, response)
+            reason = self.error_reason(workername, response)
             self.write(f"Failed to set timeouts: '{reason}'")
 
 
@@ -527,5 +527,5 @@ Change rate limit for a task
         else:
             logger.error(response)
             self.set_status(403)
-            reason = self.error_reason(taskname, response)
+            reason = self.error_reason(workername, response)
             self.write(f"Failed to set rate limit: '{reason}'")

--- a/tests/unit/api/test_control.py
+++ b/tests/unit/api/test_control.py
@@ -109,6 +109,18 @@ class WorkerControlTests(BaseApiTestCase):
             'celery.map', hard=3.1, soft=1.2, destination=['foo'],
             reply=True)
 
+    def test_task_timeout_failure_returns_worker_error_message(self):
+        celery = self._app.capp
+        celery.control.time_limit = MagicMock(
+            return_value=[{'foo': {'error': 'time limits not supported'}}])
+
+        r = self.post(
+            '/api/task/timeout/celery.map',
+            body={'workername': 'foo', 'hard': 3.1, 'soft': 1.2}
+        )
+        self.assertEqual(403, r.code)
+        self.assertEqual(b"Failed to set timeouts: 'time limits not supported'", r.body)
+
     def test_task_ratelimit(self):
         celery = self._app.capp
         celery.control.rate_limit = MagicMock(
@@ -130,6 +142,16 @@ class WorkerControlTests(BaseApiTestCase):
         self.assertEqual(200, r.code)
         celery.control.rate_limit.assert_called_once_with(
             'celery.map', '11/m', destination=['foo'], reply=True)
+
+    def test_task_ratelimit_failure_returns_worker_error_message(self):
+        celery = self._app.capp
+        celery.control.rate_limit = MagicMock(
+            return_value=[{'foo': {'error': 'Invalid rate limit string'}}])
+
+        r = self.post('/api/task/rate-limit/celery.map',
+                      body={'workername': 'foo', 'ratelimit': 'garbage'})
+        self.assertEqual(403, r.code)
+        self.assertEqual(b"Failed to set rate limit: 'Invalid rate limit string'", r.body)
 
     def test_param_escape(self):
         app = self._app.capp


### PR DESCRIPTION
## Summary

`def error_reason(self, workername, response)` expect workername as its first argument, not taskname.

**Current behaviour**: the response always is: `Failed to set rate limit: 'Unknown reason'`
**Expected behaviour**: `Failed to set rate limit: {real error}`