### PR TITLE
feat: add GitHub Device Authorization Grant (CLI auth) to GithubLoginHandler

### DIFF
--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -83,18 +83,46 @@ Here's an example configuration file with the Github OAuth options:
     oauth2_secret="<your_client_secret>"
     oauth2_redirect_uri="http://localhost:5555/login"
 
-Replace `<your_client_id>` and `<your_client_secret>` with the actual  Client ID and secret obtained from
+Replace `<your_client_id>` and `<your_client_secret>` with the actual Client ID and secret obtained from
 the Github Settings.
+
+(Optional) The custom GitHub Domain can be adjusted using the ``FLOWER_GITHUB_OAUTH_DOMAIN`` environment variable.
 
 See `GitHub OAuth API`_ docs for more info.
 
 .. _Github Settings: https://github.com/settings/applications/new
 .. _GitHub OAuth API: https://developer.github.com/v3/oauth/
 
+.. _github-device-auth:
+
+GitHub Device Auth (CLI)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``GithubLoginHandler`` also supports the `GitHub Device Authorization Grant`_ (RFC 8628)
+for CLI / browserless environments. No additional ``auth_provider`` is needed — the same
+``GithubLoginHandler`` configuration is used:
+
+.. code-block:: python
+
+    auth_provider="flower.views.auth.GithubLoginHandler"
+    auth=".*@example.com"
+    oauth2_key="<your_client_id>"
+    oauth2_secret="<your_client_secret>"
+    oauth2_redirect_uri="http://localhost:5555/login"
+
+**Prerequisites:** Enable *Device Flow* in your GitHub OAuth App settings.
+
+See `GitHub Device Authorization Grant`_ and `GitHub Device Flow API`_ docs for more info.
+
+.. _GitHub Device Authorization Grant: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow
+.. _GitHub Device Flow API: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#response-parameters
+
+
 .. _okta-oauth:
 
 Okta OAuth
 ----------
+
 
 Flower also supports Okta OAuth. Before getting started, you need to register Flower in `Okta`_.
 Okta OAuth is activated by setting :ref:`auth_provider` option to `flower.views.auth.OktaLoginHandler`.

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -87,11 +87,25 @@ class LoginHandler(BaseHandler):
 
 
 class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
+    """GitHub OAuth handler supporting both web (browser) and device (CLI) flows.
+
+    Web OAuth flow (existing behaviour):
+      - ``GET /login``              → redirect to GitHub authorize page
+      - ``GET /login?code=…``       → exchange code for token, set cookie
+
+    Device Authorization Grant (CLI / browserless, RFC 8628):
+      - ``POST /login``                      → request device+user code from GitHub,
+                                               return JSON with ``user_code`` and
+                                               ``verification_uri`` for the CLI to display
+      - ``GET /login?device_code=…``         → poll; returns 202 while pending,
+                                               302 on success
+    """
 
     _OAUTH_DOMAIN = os.getenv(
         "FLOWER_GITHUB_OAUTH_DOMAIN", "github.com")
     _OAUTH_AUTHORIZE_URL = f'https://{_OAUTH_DOMAIN}/login/oauth/authorize'
     _OAUTH_ACCESS_TOKEN_URL = f'https://{_OAUTH_DOMAIN}/login/oauth/access_token'
+    _OAUTH_DEVICE_CODE_URL = f'https://{_OAUTH_DOMAIN}/login/device/code'
     _OAUTH_NO_CALLBACKS = False
     _OAUTH_SETTINGS_KEY = 'oauth'
 
@@ -115,7 +129,30 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
 
         return json.loads(response.body.decode('utf-8'))
 
+    async def post(self):
+        """Device flow step 1: request a device + user code from GitHub."""
+        body = urlencode({
+            'client_id': self.settings[self._OAUTH_SETTINGS_KEY]['key'],
+            'scope': 'user:email',
+        })
+        response = await self.get_auth_http_client().fetch(
+            self._OAUTH_DEVICE_CODE_URL,
+            method='POST',
+            headers={'Content-Type': 'application/x-www-form-urlencoded',
+                     'Accept': 'application/json'},
+            body=body,
+        )
+        if response.error:
+            raise tornado.web.HTTPError(502, 'GitHub device code request failed')
+        self.set_header('Content-Type', 'application/json')
+        self.write(response.body)
+
     async def get(self):
+        device_code = self.get_argument('device_code', None)
+        if device_code:
+            await self._device_poll(device_code)
+            return
+
         redirect_uri = self.settings[self._OAUTH_SETTINGS_KEY]['redirect_uri']
         if self.get_argument('code', False):
             user = await self.get_authenticated_user(
@@ -131,6 +168,36 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
                 response_type='code',
                 extra_params={'approval_prompt': ''}
             )
+
+    async def _device_poll(self, device_code):
+        """Device flow step 2: poll GitHub for an access token."""
+        body = urlencode({
+            'client_id': self.settings[self._OAUTH_SETTINGS_KEY]['key'],
+            'device_code': device_code,
+            'grant_type': 'urn:ietf:params:oauth:grant-type:device_code',
+        })
+        response = await self.get_auth_http_client().fetch(
+            self._OAUTH_ACCESS_TOKEN_URL,
+            method='POST',
+            headers={'Content-Type': 'application/x-www-form-urlencoded',
+                     'Accept': 'application/json'},
+            body=body,
+        )
+        if response.error:
+            raise tornado.web.HTTPError(502, 'GitHub token poll failed')
+
+        data = json.loads(response.body.decode('utf-8'))
+        error = data.get('error')
+        if error in ('authorization_pending', 'slow_down'):
+            # User has not yet approved; caller should retry after `interval`.
+            self.set_status(202)
+            self.set_header('Content-Type', 'application/json')
+            self.write(response.body)
+            return
+        if error:
+            raise tornado.web.HTTPError(403, f'GitHub device auth error: {error}')
+
+        await self._on_auth(data)
 
     async def _on_auth(self, user):
         if not user:

--- a/flower/views/auth.py
+++ b/flower/views/auth.py
@@ -87,19 +87,6 @@ class LoginHandler(BaseHandler):
 
 
 class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
-    """GitHub OAuth handler supporting both web (browser) and device (CLI) flows.
-
-    Web OAuth flow (existing behaviour):
-      - ``GET /login``              → redirect to GitHub authorize page
-      - ``GET /login?code=…``       → exchange code for token, set cookie
-
-    Device Authorization Grant (CLI / browserless, RFC 8628):
-      - ``POST /login``                      → request device+user code from GitHub,
-                                               return JSON with ``user_code`` and
-                                               ``verification_uri`` for the CLI to display
-      - ``GET /login?device_code=…``         → poll; returns 202 while pending,
-                                               302 on success
-    """
 
     _OAUTH_DOMAIN = os.getenv(
         "FLOWER_GITHUB_OAUTH_DOMAIN", "github.com")
@@ -130,7 +117,6 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
         return json.loads(response.body.decode('utf-8'))
 
     async def post(self):
-        """Device flow step 1: request a device + user code from GitHub."""
         body = urlencode({
             'client_id': self.settings[self._OAUTH_SETTINGS_KEY]['key'],
             'scope': 'user:email',
@@ -170,7 +156,6 @@ class GithubLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
             )
 
     async def _device_poll(self, device_code):
-        """Device flow step 2: poll GitHub for an access token."""
         body = urlencode({
             'client_id': self.settings[self._OAUTH_SETTINGS_KEY]['key'],
             'device_code': device_code,

--- a/tests/unit/views/test_auth.py
+++ b/tests/unit/views/test_auth.py
@@ -73,6 +73,10 @@ _OAUTH_SETTINGS = {
 
 
 class GithubLoginHandlerDeviceFlowTests(AsyncHTTPTestCase):
+    def setUp(self):
+        super().setUp()
+        self._app.settings['oauth'] = _OAUTH_SETTINGS
+
     def test_post_returns_device_code_json(self):
         client = MagicMock()
         client.fetch = AsyncMock(return_value=MagicMock(
@@ -81,8 +85,7 @@ class GithubLoginHandlerDeviceFlowTests(AsyncHTTPTestCase):
         ))
         with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
              self.mock_option('auth', '.*@example.com'), \
-             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client), \
-             patch.dict(self.get_app().settings, {'oauth': _OAUTH_SETTINGS}):
+             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client):
             r = self.fetch('/login', method='POST', body='')
             self.assertEqual(200, r.code)
             self.assertEqual('ABCD-1234', json.loads(r.body)['user_code'])
@@ -95,8 +98,7 @@ class GithubLoginHandlerDeviceFlowTests(AsyncHTTPTestCase):
         ))
         with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
              self.mock_option('auth', '.*@example.com'), \
-             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client), \
-             patch.dict(self.get_app().settings, {'oauth': _OAUTH_SETTINGS}):
+             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client):
             r = self.fetch('/login?device_code=dev123')
             self.assertEqual(202, r.code)
 
@@ -108,8 +110,7 @@ class GithubLoginHandlerDeviceFlowTests(AsyncHTTPTestCase):
         ))
         with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
              self.mock_option('auth', '.*@example.com'), \
-             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client), \
-             patch.dict(self.get_app().settings, {'oauth': _OAUTH_SETTINGS}):
+             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client):
             r = self.fetch('/login?device_code=dev123')
             self.assertEqual(403, r.code)
 
@@ -122,8 +123,7 @@ class GithubLoginHandlerDeviceFlowTests(AsyncHTTPTestCase):
         ])
         with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
              self.mock_option('auth', '.*@example.com'), \
-             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client), \
-             patch.dict(self.get_app().settings, {'oauth': _OAUTH_SETTINGS}):
+             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client):
             r = self.fetch('/login?device_code=dev123', follow_redirects=False)
             self.assertEqual(302, r.code)
             self.assertIn('user', r.headers.get('Set-Cookie', ''))

--- a/tests/unit/views/test_auth.py
+++ b/tests/unit/views/test_auth.py
@@ -65,90 +65,65 @@ class AuthTests(AsyncHTTPTestCase):
         self.assertFalse(authenticate(".*@corp\\.example\\.com", "attacker@corpZexample.com"))
 
 
-def _mock_response(body, error=None):
-    resp = MagicMock()
-    resp.error = error
-    resp.body = json.dumps(body).encode()
-    return resp
+_OAUTH_SETTINGS = {
+    'key': 'test-client-id',
+    'secret': 'test-client-secret',
+    'redirect_uri': 'http://localhost:5555/login',
+}
 
 
 class GithubLoginHandlerDeviceFlowTests(AsyncHTTPTestCase):
-    _OAUTH_SETTINGS = {
-        'key': 'test-client-id',
-        'secret': 'test-client-secret',
-        'redirect_uri': 'http://localhost:5555/login',
-    }
-
-    def _make_http_client(self, response):
-        client = MagicMock()
-        client.fetch = AsyncMock(return_value=response)
-        return client
-
-    # ------------------------------------------------------------------
-    # POST /login – step 1: request device code
-    # ------------------------------------------------------------------
     def test_post_returns_device_code_json(self):
-        device_payload = {
-            'device_code': 'dev123',
-            'user_code': 'ABCD-1234',
-            'verification_uri': 'https://github.com/login/device',
-            'interval': 5,
-            'expires_in': 900,
-        }
+        client = MagicMock()
+        client.fetch = AsyncMock(return_value=MagicMock(
+            error=None,
+            body=json.dumps({'user_code': 'ABCD-1234'}).encode(),
+        ))
         with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
-             self.mock_option('auth', '.*@example.com'):
-            resp = _mock_response(device_payload)
-            with patch(
-                'flower.views.auth.GithubLoginHandler.get_auth_http_client',
-                return_value=self._make_http_client(resp),
-            ), patch.dict(self.get_app().settings, {'oauth': self._OAUTH_SETTINGS}):
-                r = self.fetch('/login', method='POST', body='')
-                self.assertEqual(200, r.code)
-                data = json.loads(r.body)
-                self.assertEqual('ABCD-1234', data['user_code'])
+             self.mock_option('auth', '.*@example.com'), \
+             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client), \
+             patch.dict(self.get_app().settings, {'oauth': _OAUTH_SETTINGS}):
+            r = self.fetch('/login', method='POST', body='')
+            self.assertEqual(200, r.code)
+            self.assertEqual('ABCD-1234', json.loads(r.body)['user_code'])
 
-    # ------------------------------------------------------------------
-    # GET /login?device_code=… – step 2: poll
-    # ------------------------------------------------------------------
     def test_get_authorization_pending_returns_202(self):
-        pending = {'error': 'authorization_pending', 'error_description': 'pending'}
+        client = MagicMock()
+        client.fetch = AsyncMock(return_value=MagicMock(
+            error=None,
+            body=json.dumps({'error': 'authorization_pending'}).encode(),
+        ))
         with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
-             self.mock_option('auth', '.*@example.com'):
-            resp = _mock_response(pending)
-            with patch(
-                'flower.views.auth.GithubLoginHandler.get_auth_http_client',
-                return_value=self._make_http_client(resp),
-            ), patch.dict(self.get_app().settings, {'oauth': self._OAUTH_SETTINGS}):
-                r = self.fetch('/login?device_code=dev123')
-                self.assertEqual(202, r.code)
+             self.mock_option('auth', '.*@example.com'), \
+             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client), \
+             patch.dict(self.get_app().settings, {'oauth': _OAUTH_SETTINGS}):
+            r = self.fetch('/login?device_code=dev123')
+            self.assertEqual(202, r.code)
 
     def test_get_device_auth_error_returns_403(self):
-        expired = {'error': 'expired_token', 'error_description': 'Token expired'}
+        client = MagicMock()
+        client.fetch = AsyncMock(return_value=MagicMock(
+            error=None,
+            body=json.dumps({'error': 'expired_token'}).encode(),
+        ))
         with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
-             self.mock_option('auth', '.*@example.com'):
-            resp = _mock_response(expired)
-            with patch(
-                'flower.views.auth.GithubLoginHandler.get_auth_http_client',
-                return_value=self._make_http_client(resp),
-            ), patch.dict(self.get_app().settings, {'oauth': self._OAUTH_SETTINGS}):
-                r = self.fetch('/login?device_code=dev123')
-                self.assertEqual(403, r.code)
+             self.mock_option('auth', '.*@example.com'), \
+             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client), \
+             patch.dict(self.get_app().settings, {'oauth': _OAUTH_SETTINGS}):
+            r = self.fetch('/login?device_code=dev123')
+            self.assertEqual(403, r.code)
 
     def test_get_successful_auth_sets_cookie_and_redirects(self):
-        token_resp = {'access_token': 'tok123', 'token_type': 'bearer'}
-        emails_resp = [{'email': 'user@example.com', 'verified': True, 'primary': True}]
+        client = MagicMock()
+        client.fetch = AsyncMock(side_effect=[
+            MagicMock(error=None, body=json.dumps({'access_token': 'tok123'}).encode()),
+            MagicMock(error=None, body=json.dumps(
+                [{'email': 'user@example.com', 'verified': True}]).encode()),
+        ])
         with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
-             self.mock_option('auth', '.*@example.com'):
-            # First fetch call → access token; second → email list
-            client = MagicMock()
-            client.fetch = AsyncMock(side_effect=[
-                _mock_response(token_resp),
-                _mock_response(emails_resp),
-            ])
-            with patch(
-                'flower.views.auth.GithubLoginHandler.get_auth_http_client',
-                return_value=client,
-            ), patch.dict(self.get_app().settings, {'oauth': self._OAUTH_SETTINGS}):
-                r = self.fetch('/login?device_code=dev123', follow_redirects=False)
-                self.assertEqual(302, r.code)
-                self.assertIn('user', r.headers.get('Set-Cookie', ''))
+             self.mock_option('auth', '.*@example.com'), \
+             patch('flower.views.auth.GithubLoginHandler.get_auth_http_client', return_value=client), \
+             patch.dict(self.get_app().settings, {'oauth': _OAUTH_SETTINGS}):
+            r = self.fetch('/login?device_code=dev123', follow_redirects=False)
+            self.assertEqual(302, r.code)
+            self.assertIn('user', r.headers.get('Set-Cookie', ''))

--- a/tests/unit/views/test_auth.py
+++ b/tests/unit/views/test_auth.py
@@ -66,7 +66,6 @@ class AuthTests(AsyncHTTPTestCase):
 
 
 def _mock_response(body, error=None):
-    """Build a minimal mock that looks like a tornado HTTPResponse."""
     resp = MagicMock()
     resp.error = error
     resp.body = json.dumps(body).encode()

--- a/tests/unit/views/test_auth.py
+++ b/tests/unit/views/test_auth.py
@@ -1,3 +1,6 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
 from flower.views.auth import authenticate, validate_auth_option
 from tests.unit import AsyncHTTPTestCase
 
@@ -59,4 +62,94 @@ class AuthTests(AsyncHTTPTestCase):
         self.assertTrue(authenticate("one.*@example.com", "one.two@example.com"))
         self.assertFalse(authenticate(".*@example.com", "attacker@example.com.attacker.com"))
         self.assertFalse(authenticate(".*@corp.example.com", "attacker@corpZexample.com"))
-        self.assertFalse(authenticate(".*@corp\.example\.com", "attacker@corpZexample.com"))
+        self.assertFalse(authenticate(".*@corp\\.example\\.com", "attacker@corpZexample.com"))
+
+
+def _mock_response(body, error=None):
+    """Build a minimal mock that looks like a tornado HTTPResponse."""
+    resp = MagicMock()
+    resp.error = error
+    resp.body = json.dumps(body).encode()
+    return resp
+
+
+class GithubLoginHandlerDeviceFlowTests(AsyncHTTPTestCase):
+    _OAUTH_SETTINGS = {
+        'key': 'test-client-id',
+        'secret': 'test-client-secret',
+        'redirect_uri': 'http://localhost:5555/login',
+    }
+
+    def _make_http_client(self, response):
+        client = MagicMock()
+        client.fetch = AsyncMock(return_value=response)
+        return client
+
+    # ------------------------------------------------------------------
+    # POST /login – step 1: request device code
+    # ------------------------------------------------------------------
+    def test_post_returns_device_code_json(self):
+        device_payload = {
+            'device_code': 'dev123',
+            'user_code': 'ABCD-1234',
+            'verification_uri': 'https://github.com/login/device',
+            'interval': 5,
+            'expires_in': 900,
+        }
+        with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
+             self.mock_option('auth', '.*@example.com'):
+            resp = _mock_response(device_payload)
+            with patch(
+                'flower.views.auth.GithubLoginHandler.get_auth_http_client',
+                return_value=self._make_http_client(resp),
+            ), patch.dict(self.get_app().settings, {'oauth': self._OAUTH_SETTINGS}):
+                r = self.fetch('/login', method='POST', body='')
+                self.assertEqual(200, r.code)
+                data = json.loads(r.body)
+                self.assertEqual('ABCD-1234', data['user_code'])
+
+    # ------------------------------------------------------------------
+    # GET /login?device_code=… – step 2: poll
+    # ------------------------------------------------------------------
+    def test_get_authorization_pending_returns_202(self):
+        pending = {'error': 'authorization_pending', 'error_description': 'pending'}
+        with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
+             self.mock_option('auth', '.*@example.com'):
+            resp = _mock_response(pending)
+            with patch(
+                'flower.views.auth.GithubLoginHandler.get_auth_http_client',
+                return_value=self._make_http_client(resp),
+            ), patch.dict(self.get_app().settings, {'oauth': self._OAUTH_SETTINGS}):
+                r = self.fetch('/login?device_code=dev123')
+                self.assertEqual(202, r.code)
+
+    def test_get_device_auth_error_returns_403(self):
+        expired = {'error': 'expired_token', 'error_description': 'Token expired'}
+        with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
+             self.mock_option('auth', '.*@example.com'):
+            resp = _mock_response(expired)
+            with patch(
+                'flower.views.auth.GithubLoginHandler.get_auth_http_client',
+                return_value=self._make_http_client(resp),
+            ), patch.dict(self.get_app().settings, {'oauth': self._OAUTH_SETTINGS}):
+                r = self.fetch('/login?device_code=dev123')
+                self.assertEqual(403, r.code)
+
+    def test_get_successful_auth_sets_cookie_and_redirects(self):
+        token_resp = {'access_token': 'tok123', 'token_type': 'bearer'}
+        emails_resp = [{'email': 'user@example.com', 'verified': True, 'primary': True}]
+        with self.mock_option('auth_provider', 'flower.views.auth.GithubLoginHandler'), \
+             self.mock_option('auth', '.*@example.com'):
+            # First fetch call → access token; second → email list
+            client = MagicMock()
+            client.fetch = AsyncMock(side_effect=[
+                _mock_response(token_resp),
+                _mock_response(emails_resp),
+            ])
+            with patch(
+                'flower.views.auth.GithubLoginHandler.get_auth_http_client',
+                return_value=client,
+            ), patch.dict(self.get_app().settings, {'oauth': self._OAUTH_SETTINGS}):
+                r = self.fetch('/login?device_code=dev123', follow_redirects=False)
+                self.assertEqual(302, r.code)
+                self.assertIn('user', r.headers.get('Set-Cookie', ''))


### PR DESCRIPTION
## Summary

Adds support for the [GitHub Device Authorization Grant](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow) (RFC 8628) directly inside the existing `GithubLoginHandler`, enabling CLI / browserless authentication without a separate handler class.

This is particularly useful when building custom integrations like Model Context Protocol (MCP) servers, allowing headless CLI environments to securely authenticate and access the tasks API.

Also documents the `FLOWER_GITHUB_OAUTH_DOMAIN` environment variable which partially addresses #1308 (GitHub Enterprise Server support).

## How to Test

### Setup
Configure `flowerconfig.py` with GitHub OAuth details and start Flower:
```bash
celery flower --auth_provider="flower.views.auth.GithubLoginHandler" \
              --auth="your-email@example.com" \
              --oauth2_key="<client_id>" \
              --oauth2_secret="<client_secret>"
```

### Steps
1. **Request Device Code (POST):**
   ```bash
   curl -X POST http://localhost:5555/login
   ```
   *Expected Response:* JSON containing `device_code`, `user_code`, `verification_uri`.

2. **Authorize Device:**
   Go to the `verification_uri` in your browser and enter the `user_code`.

3. **Poll for Auth status (GET):**
   Query the polling endpoint:
   ```bash
   curl -i "http://localhost:5555/login?device_code=<device_code>"
   ```
   * *Before authorization:* Returns `202 Accepted` (`authorization_pending`).
   * *After authorization:* Returns `302 Found` with `Location: /` and sets the session cookie.

## Changes

### `flower/views/auth.py`
- Added `_OAUTH_DEVICE_CODE_URL` class attribute
- Added `post()` — device flow step 1: requests `device_code` + `user_code` from GitHub, returns JSON
- Added `_device_poll()` — device flow step 2: polls for access token, returns `202` while pending, `302` on success
- Existing web OAuth flow (`GET /login`, `GET /login?code=…`) is unchanged

### `tests/unit/views/test_auth.py`
- 4 new unit tests covering: device code request (POST), authorization pending (202), auth error (403), and successful auth with cookie + redirect (302)

### `docs/auth.rst`
- Added **GitHub Device Auth (CLI)** subsection with config example and links to GitHub docs
- Documented `FLOWER_GITHUB_OAUTH_DOMAIN` environment variable in the GitHub OAuth section (relates to #1308)

## No breaking changes
The existing OAuth web flow behaviour is fully preserved.