### PR TITLE
fix: prevent NaN in workers Active total when a worker reports null active

### DIFF
--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -363,7 +363,8 @@ var flower = (function () {
     });
 
     function sum(a, b) {
-        return parseInt(a, 10) + parseInt(b, 10);
+        var x = parseInt(a, 10), y = parseInt(b, 10);
+        return (isNaN(x) ? 0 : x) + (isNaN(y) ? 0 : y);
     }
 
     function format_time(timestamp) {


### PR DESCRIPTION
The workers table footer sums each column via reduce(sum, 0). The 'active' value comes from the worker heartbeat stats and can be null/undefined (unlike the event-counter columns that default to 0), so parseInt(null) yielded NaN and poisoned the Active total. This treats non-numeric values as 0, consistent with the column's defaultContent: 0.