### PR TITLE
fix: require state: prefix in task search parser

### DIFF
--- a/flower/utils/search.py
+++ b/flower/utils/search.py
@@ -25,7 +25,7 @@ def parse_search_terms(raw_search_value):
             except ValueError:
                 continue
             parsed_search['kwargs'][key] = preprocess_search_value(value)
-        elif query_part.startswith('state'):
+        elif query_part.startswith('state:'):
             if 'state' not in parsed_search:
                 parsed_search['state'] = []
             parsed_search['state'].append(preprocess_search_value(query_part[len('state:'):]))

--- a/tests/unit/utils/test_search.py
+++ b/tests/unit/utils/test_search.py
@@ -68,6 +68,12 @@ class TestSearchParser(unittest.TestCase):
             parse_search_terms('kwargs:some_kwarg1="some value1" kwargs:some_kwarg2="some value2"')
         )
 
+    def test_state(self):
+        self.assertEqual(
+            {'state': ['STARTED']},
+            parse_search_terms('state:STARTED')
+        )
+
 
 class TestStringfiedDictChecker(unittest.TestCase):
     def test_stringifies_args(self):


### PR DESCRIPTION
Closes #1515 

Task search now matches `state:`